### PR TITLE
fixed the last couple {.is-info} tags

### DIFF
--- a/docs/knowledge-base/posts/proper-power-sequence.md
+++ b/docs/knowledge-base/posts/proper-power-sequence.md
@@ -22,16 +22,16 @@ dateCreated: 2024-06-24T13:49:31.305Z
 To power off a cluster (a collection of two or more nodes) follow these steps:
 
 1. Check any running workloads on each node of the cluster. Navigate to the node dashboard for each node and review the **Running Machines** section.
-1. If there are tenants running on any of the nodes, log into those tenant environments and gracefully shut down all running workloads.
-1. Power off all running workloads on each node, including VMs, tenant nodes, VMware backup services, and NAS services (if applicable).
-    > **Note:** There’s no need to manually stop any running vNet Containers; they will be gracefully stopped automatically in the subsequent steps.
-    {.is-info}
-1. After stopping all running workloads, navigate to the **Cluster dashboard** for the cluster you wish to power off.
-1. Select **Power Off** from the left-hand menu to begin shutting down each node in the cluster.
-1. Finally, navigate to **System -> Clusters** and select **Power Off** in the left menu to power off the entire cluster.
-    > **Important:** If an environment contains multiple clusters, _**ALWAYS**_ shut down the cluster containing the controller nodes (Node1 & Node2) _**LAST**_!
-    {.is-warning}
+2. If there are tenants running on any of the nodes, log into those tenant environments and gracefully shut down all running workloads.
+3. Power off all running workloads on each node, including VMs, tenant nodes, VMware backup services, and NAS services (if applicable).  
+!!! info "vNet Containers"
+    There is no need to manually stop any running vNet containers; they will be gracefully stopped automatically in the subsequent steps.
 
+4. After stopping all running workloads, navigate to the **Cluster dashboard** for the cluster you wish to power off.
+5. Select **Power Off** from the left-hand menu to begin shutting down each node in the cluster.
+6. Finally, navigate to **System -> Clusters** and select **Power Off** in the left menu to power off the entire cluster.
+!!! warning "IMPORTANT"
+    If an environment contains multiple clusters, _**ALWAYS**_ shut down the cluster containing the controller nodes (Node1 & Node2) **LAST**.
 
 ---
 

--- a/docs/knowledge-base/posts/win11-bypass-tpm.md
+++ b/docs/knowledge-base/posts/win11-bypass-tpm.md
@@ -22,13 +22,10 @@ dateCreated: 2022-10-28T14:00:42.477Z
 
 ---
 
-!!! warning "**This only applies to Versions of Verge.io previous to 4.11 (Atria).**"
-
+!!! warning "**This only applies to versions of VergeOS previous to 4.11 (Atria).**"
 
 If you have the Windows 11 install disk or ISO, you can bypass the Windows TPM and RAM requirements by making registry changes during the install.  
-> **Note:** This method only works on a clean install and does not allow you to bypass the requirement for at least a dual-core CPU. 
-{.is-info}
-
+!!! info "This method only works on a clean install and does not allow you to bypass the requirement for at least a dual-core CPU."
 
 1. **Boot** off of your Windows 11 install disk. [If you don't have one, one can be downloaded from here.](https://www.microsoft.com/en-us/software-download/windows11) The first screen should ask you to choose the language of your install (which should be correct).
 ![tpm-1.png](/product-guide/screenshots/tpm-1.png)

--- a/docs/product-guide/virtual-machines/vdi-overview.md
+++ b/docs/product-guide/virtual-machines/vdi-overview.md
@@ -3,15 +3,5 @@
 
 VDI functionality allows for hosting virtual desktops and provides an individualized VDI Dashboard for each user to access virtual desktops.
 
--   Help for the **VDI User** can be found at: [**Instructions for the VDI User**](/product-guide/system/vdi-user)
--   Help for the **VDI Admin** can be found at: [**Instructions for the VDI Admin**](/product-guide/system/vdi-administrator)
-
-<br>   
-
-   > If you would like to request a KB based on a specific subject, please email our support team at <a href="mailto:support@verge.io?subject=KB Request" target="_blank" rel="noopener noreferrer">support@verge.io.</a>{.is-info}
-
-
-
-<br>
-
-[Get vergeOS license keys](https://www.verge.io/test-drive){ target="_blank" .md-button }
+* Help for the **VDI User** can be found at: [**Instructions for the VDI User**](/product-guide/virtual-machines/vdi-user)
+* Help for the **VDI Administrator** can be found at: [**Instructions for the VDI Admin**](/product-guide/virtual-machines/vdi-administrator)


### PR DESCRIPTION
fixed the last couple {.is-info} tags to the correct format so we can mark the item done on the Trello board.
2 kb articles and an unlinked vdi-overview page that may still be useful in user searches