### PR TITLE
fixed - one page had the old request trial link

### DIFF
--- a/docs/product-guide/virtual-machines/import-vms.md
+++ b/docs/product-guide/virtual-machines/import-vms.md
@@ -1,20 +1,13 @@
 
-
 # VM Import Methods
 
 Multiple methods are available for importing existing VMs into VergeOS:
 
-<br>
-
 - [**From Media Images**](/product-guide/virtual-machines/import-from-upload)
-To import one VM at a time; requires the upload of VM media files (*.vmx, *.vhd(x), *.qcow, *.etc.) to the vSAN.
-<br>
+To import one VM at a time; requires the upload of VM media files (*.vmx,*.vhd(x), *.qcow,*.etc.) to the vSAN.
 
 - [**From a VMware Service Backup Job**](/product-guide/virtual-machines/import-from-vmware)
 Data is accessed using the **VMware agent** for direct connection (independent of storage hardware). This is the best method for importing multiple VMs from a running, production VMware environment.
-<br>
+
 - [**From a NAS Volume**](/product-guide/virtual-machines/import-from-nas)
 Data is pulled from **CIFS or NFS share** accessing existing VM data storage.
-<br>
-
-[Get vergeOS license keys](https://www.verge.io/test-drive){ target="_blank" .md-button }


### PR DESCRIPTION

- Removed the "request a trial" link from the vm-imports page 
- Removed unnecessary breaks and spaces while in there. 


We can now clear this todo item from Trello