### PR TITLE
Update nodes-overview.md

### DIFF
--- a/docs/product-guide/system/nodes-overview.md
+++ b/docs/product-guide/system/nodes-overview.md
@@ -14,8 +14,6 @@ A node in VergeOS represents a physical or virtual server that contributes compu
 ### Resource Metrics
 
 - **CPU Usage**: Real-time monitoring of processor utilization
-- **RAM Usage**: Physical and virtual memory allocation and consumption
-- **Temperature**: System temperature monitoring (where supported)
 - **Storage**: Drive status and utilization
 
 ### Node Statistics
@@ -24,9 +22,10 @@ The dashboard provides key metrics for:
 
 - Physical RAM utilization
 - Virtual RAM allocation
+- Temperature
+- Running Machines
 - Core usage
-- Running machines
-- Storage tier status
+- Machine RAM Usage
 
 ### Connected Devices
 


### PR DESCRIPTION
Updated the Node Statistics section to include "Temperature" and "Machine RAM Usage", and removed those references from under "Resource Metrics".  The Machine RAM Usage is actually under a dashboard header called "Machine Statistics", but it looks like those metrics are included here under Node Statistics.

Not sure if they need to be broken out but the following sections in the dashboard have the following metrics:

Node Statistics
- Physical RAM Utilization
- Virtual RAM Allocation
- Temperature 

Machine Statistics
- Running Machines
- Core Usage
- RAM Usage