### PR TITLE
Update licensing-and-updates.md

### DIFF
--- a/docs/product-guide/system/licensing-and-updates.md
+++ b/docs/product-guide/system/licensing-and-updates.md
@@ -24,7 +24,7 @@ The dashboard displays key information about the update server:
 - **Name**: Update server name (Verge.io Updates)
 - **Description**: Server purpose and capabilities
 - **URL**: Update server address
-- **Account User**: Authentication credentials
+- **Account User**: Account Username
 - **Last Checked**: Timestamp of last update check
 - **Last Updated**: Timestamp of last successful update
 


### PR DESCRIPTION
Updated the description of the Account User in the Update Server Dashboard section to state "Account Username" instead of "Authentication Credentials".