### PR TITLE
Update network-design.md

### DIFF
--- a/docs/implementation-guide/network-design.md
+++ b/docs/implementation-guide/network-design.md
@@ -27,7 +27,7 @@ This model uses a bonded Layer 2 network for the External, UI and API Management
 
 ### Requirements
 
-- 4 x 10/25/40/100GbE NIC ports per node
+- 4 x 10/25/40/100GbE network ports per node
 - Switching infrastructure that supports stacking (MLAG) - For External Network
 
 ### Network Configuration
@@ -60,7 +60,6 @@ This model uses dynamically advertised Layer 3 networks for the External, UI and
 ### Requirements
 
 - 4 x 10/25/40/100Gb network adapter ports per controller node
-- 2 x 10/25/40/100Gb network adapter ports per additional node
 - A layer 3 network External to the System that VergeOS can peer with
 - BGP, OSPF, or EIGRP capabilities
 - Using VergeOS Internal Networks for workloads
@@ -95,7 +94,6 @@ This model uses a bonded Layer 3 network for the External, UI and API Management
 ### Requirements
 
 - 4 x 10/25/40/100Gb network adapter ports per controller node
-- 2 x 10/25/40/100Gb network adapter ports per additional node
 - Switching infrastructure that supports stacking (MLAG) - For External Network
 - Layer 3 capable switching infrastructure for the External network
 - Using VergeOS Internal Networks for workloads
@@ -117,11 +115,11 @@ This model uses a bonded Layer 3 network for the External, UI and API Management
 
 ![Layer 3 Bonded + Dedicated Core](/assets/layer3bonded-dc.png)
 
-## Layer 2 Static using 2 NIC ports
+## Layer 2 Static using 2 network ports
 
 In this model, all networks (Core Fabric, External/Management, Workloads) are combined into a single bonded network VergeOS Physical Network.
 
-### Use Cases - 2 NIC ports
+### Use Cases - 2 network ports
 
 - Proof of concepts
 - Small Edge deployments
@@ -131,12 +129,12 @@ In this model, all networks (Core Fabric, External/Management, Workloads) are co
 
 !!! note "Each statically assigned network you route to VergeOS in this system design will be non-redundant"
 
-### Requirements - 2 NIC ports
+### Requirements - 2 network ports
 
 - 2 x 10/25/40/100GbE network adapter ports per node
 - Ability to trunk VLANs and set a native VLAN on switch
 
-### Network Configuration - 2 NIC ports
+### Network Configuration - 2 network ports
 
 - 2 Physical Networks
 
@@ -148,7 +146,7 @@ In this model, all networks (Core Fabric, External/Management, Workloads) are co
 - A single VLAN for UI/API Management (Either Core Fabric Network)
 - Any other VLANs required for your workloads (Either Core Fabric Network)
 
-### Diagram - 2 NIC ports
+### Diagram - 2 network ports
 
 ![Layer 2 Bonded](/assets/2nic.png)
 

--- a/docs/implementation-guide/network-design.md
+++ b/docs/implementation-guide/network-design.md
@@ -27,7 +27,7 @@ This model uses a bonded Layer 2 network for the External, UI and API Management
 
 ### Requirements
 
-- 4 x 10/25/40/100GbE NICs
+- 4 x 10/25/40/100GbE NIC ports per node
 - Switching infrastructure that supports stacking (MLAG) - For External Network
 
 ### Network Configuration
@@ -59,7 +59,8 @@ This model uses dynamically advertised Layer 3 networks for the External, UI and
 
 ### Requirements
 
-- 4 x 10/25/40/100Gb network adapters
+- 4 x 10/25/40/100Gb network adapter ports per controller node
+- 2 x 10/25/40/100Gb network adapter ports per additional node
 - A layer 3 network External to the System that VergeOS can peer with
 - BGP, OSPF, or EIGRP capabilities
 - Using VergeOS Internal Networks for workloads
@@ -93,7 +94,8 @@ This model uses a bonded Layer 3 network for the External, UI and API Management
 
 ### Requirements
 
-- 4 x 10/25/40/100Gb network adapters
+- 4 x 10/25/40/100Gb network adapter ports per controller node
+- 2 x 10/25/40/100Gb network adapter ports per additional node
 - Switching infrastructure that supports stacking (MLAG) - For External Network
 - Layer 3 capable switching infrastructure for the External network
 - Using VergeOS Internal Networks for workloads
@@ -115,11 +117,11 @@ This model uses a bonded Layer 3 network for the External, UI and API Management
 
 ![Layer 3 Bonded + Dedicated Core](/assets/layer3bonded-dc.png)
 
-## Layer 2 Static using 2 NICs
+## Layer 2 Static using 2 NIC ports
 
 In this model, all networks (Core Fabric, External/Management, Workloads) are combined into a single bonded network VergeOS Physical Network.
 
-### Use Cases - 2 NICs
+### Use Cases - 2 NIC ports
 
 - Proof of concepts
 - Small Edge deployments
@@ -129,12 +131,12 @@ In this model, all networks (Core Fabric, External/Management, Workloads) are co
 
 !!! note "Each statically assigned network you route to VergeOS in this system design will be non-redundant"
 
-### Requirements - 2 NICs
+### Requirements - 2 NIC ports
 
-- 2 x 10/25/40/100GbE network adapters
+- 2 x 10/25/40/100GbE network adapter ports per node
 - Ability to trunk VLANs and set a native VLAN on switch
 
-### Network Configuration - 2 NICs
+### Network Configuration - 2 NIC ports
 
 - 2 Physical Networks
 
@@ -146,7 +148,7 @@ In this model, all networks (Core Fabric, External/Management, Workloads) are co
 - A single VLAN for UI/API Management (Either Core Fabric Network)
 - Any other VLANs required for your workloads (Either Core Fabric Network)
 
-### Diagram - 2 NICs
+### Diagram - 2 NIC ports
 
 ![Layer 2 Bonded](/assets/2nic.png)
 


### PR DESCRIPTION
Updated the wording to more closely match what is depicted in the diagrams, changing the term "NIC" and "network adapter" to "NIC ports" and "network adapter ports", respectively.     Also, updated the wording of the requirements to more closely match the diagrams.  I was considering using one of the terms throughout this page, either "NIC port" or "network adapter port", for consistency, but left both terms in.