### PR TITLE
Document default admin email notifications for alarms

### DIFF
--- a/docs/product-guide/operations/alarms.md
+++ b/docs/product-guide/operations/alarms.md
@@ -12,6 +12,10 @@ The VergeOS alarm system provides proactive monitoring and alerting to notify of
 
 ## Alarm Notifications
 
+!!! tip "Default Administrator Email Notifications"
+    By default, the built‑in admin user and the Administrators group receive automatic email notifications whenever a system alarm is raised or lowered (cleared)
+
+
 ### Top Bar Indicator
 
 When active alarms are present in your system, a notification badge will appear next to the alarm icon <i class="bi bi-bell"></i> (bell) on the right side of the top navigation bar. This badge displays the total number of current, active, **non-snoozed** alarms requiring attention.


### PR DESCRIPTION
This functionality is now verified working.  Adding a line to the the alarms page to note that automatic emails are sent to admin/administrator when an alarm is raised or lowered. 