### PR TITLE
Expand Linux VM import guide with detailed chroot and distro-specific instructions

### DIFF
--- a/docs/knowledge-base/posts/import-centos-redhat.md
+++ b/docs/knowledge-base/posts/import-centos-redhat.md
@@ -1,9 +1,9 @@
 ---
-title: How to Import a RedHat / RHEL / CentOS based VM
+title: How to Import a Linux VM (RHEL, CentOS, SUSE, Debian, Ubuntu)
 slug: import-rhel-centos-vm
-description: Importing RedHat / RHEL / CentOS based VMs from other hypervisors and configuring drivers for proper booting in VergeOS.
+description: Importing Linux VMs from other hypervisors and configuring virtio drivers for proper booting in VergeOS.
 draft: false
-date: 2024-09-09T15:26:24.755Z
+date: 2025-01-23T00:00:00.000Z
 tags:
   - vm
   - import
@@ -23,6 +23,13 @@ tags:
   - vm wont boot
   - wont start
   - import vm
+  - rhel
+  - centos
+  - suse
+  - debian
+  - ubuntu
+  - dracut
+  - initramfs
 categories:
   - Migration
   - Troubleshooting
@@ -30,16 +37,17 @@ editor: markdown
 dateCreated: 2024-09-09T14:38:43.388Z
 ---
 
-# How to Import a RedHat / RHEL / CentOS based VM
+# How to Import a Linux VM (RHEL, CentOS, SUSE, Debian, Ubuntu)
 
 ## Overview
 
 !!! info "Key Points"
-     - Redhat/CentOS installs drivers only for the detected hardware during installation.
-     - Imported VMs may fail to boot due to missing drivers for new hardware.
-     - You can resolve these boot issues by adjusting hardware configuration and regenerating the `initramfs`.
+     - Linux distributions install drivers only for detected hardware during installation.
+     - Imported VMs may fail to boot due to missing virtio drivers for VergeOS hardware.
+     - You can resolve boot issues by adjusting VM configuration and regenerating the initramfs.
+     - This guide covers RHEL, CentOS, Fedora, SUSE, openSUSE, Debian, and Ubuntu.
 
-This guide explains how to import Redhat/CentOS based virtual machines from other hypervisors into VergeOS. It addresses potential problems like VMs not booting or lacking network connectivity after migration.
+This guide explains how to import Linux virtual machines from other hypervisors into VergeOS. It addresses potential problems like VMs not booting or lacking network connectivity after migration, and provides distribution-specific instructions for regenerating the initramfs.
 
 ## Prerequisites
 
@@ -69,27 +77,127 @@ This guide explains how to import Redhat/CentOS based virtual machines from othe
 2. **Select Rescue Mode**:
     - In the GRUB menu, select the rescue mode to boot into a minimal recovery environment.
 
-### 3. Rebuild Initramfs
+!!! tip "SUSE/openSUSE Alternative"
+    If you cannot boot to rescue mode from GRUB (common with SLES15 and openSUSE Leap 15), mount an installation ISO to the VM and boot from it. The ISO will provide a "Rescue System" option.
 
-1. **Log into the Terminal**:
-    - Once in rescue mode, access the terminal via the VM console.
+### 3. Mount the Root Filesystem and Chroot
 
-2. **Regenerate Initramfs**:
-    - Run the following command to regenerate the initramfs with the necessary drivers:
-     ```bash
-     sudo dracut -f --regenerate-all --add-drivers "virtio_blk virtio_net"
-     ```
-    - This command adds drivers for `virtio_blk` (block device) and `virtio_net` (network device) to the initramfs, allowing the VM to boot with the correct drivers for VergeOS.
+Once booted into rescue mode, log in as root and mount the root filesystem.
 
-### 4. Reboot and Verify
+1. **Find the root partition**:
 
-1. **Reboot the VM**:
-    - After regenerating the initramfs, reboot the VM by running:
-     ```bash
-     reboot
-     ```
+    If you don't know which partition contains the root filesystem, list all available partitions:
 
-2. **Verify Boot and Network Connectivity**:
+    ```bash
+    cat /proc/partitions
+    ```
+
+    For systems using LVM, list all logical volumes:
+
+    ```bash
+    lvdisplay
+    ```
+
+2. **Mount the root partition**:
+
+    Mount the root partition or logical volume to `/mnt`:
+
+    ```bash
+    mount /dev/<device_name> /mnt
+    ```
+
+    Replace `<device_name>` with your root partition (e.g., `sda2`, `mapper/vg0-root`).
+
+3. **Verify the mount**:
+
+    Check that you mounted the correct filesystem by listing its contents:
+
+    ```bash
+    ls /mnt
+    ```
+
+    You should see directories like `/root`, `/boot`, `/home`, `/etc`, and `/var`.
+
+4. **Bind the virtual filesystems**:
+
+    Use the following for-loop to bind the necessary virtual filesystems:
+
+    ```bash
+    for i in proc sys dev run; do mount --rbind /$i /mnt/$i; done
+    ```
+
+    Alternatively, mount them individually:
+
+    ```bash
+    mount --rbind /proc /mnt/proc
+    mount --rbind /sys /mnt/sys
+    mount --rbind /dev /mnt/dev
+    mount --rbind /run /mnt/run
+    ```
+
+5. **Chroot into the mounted filesystem**:
+
+    ```bash
+    chroot /mnt
+    ```
+
+6. **Mount remaining filesystems**:
+
+    After chrooting, mount any additional partitions defined in fstab:
+
+    ```bash
+    mount -a
+    ```
+
+### 4. Rebuild Initramfs
+
+After chrooting into the system, regenerate the initramfs with the necessary virtio drivers.
+
+#### RHEL / CentOS / Fedora / SUSE (using dracut)
+
+Run the following command to regenerate the initramfs:
+
+```bash
+dracut -f --regenerate-all --add-drivers "virtio_blk virtio_net virtio_pci"
+```
+
+This adds drivers for `virtio_blk` (block device), `virtio_net` (network device), and `virtio_pci` (PCI bus) to the initramfs.
+
+#### Debian / Ubuntu (using update-initramfs)
+
+If `dracut` is not available (common on Debian 10 and Ubuntu), use `update-initramfs` instead:
+
+1. Add the virtio modules to the initramfs configuration:
+
+    ```bash
+    cat >> /etc/initramfs-tools/modules << EOF
+    virtio_pci
+    virtio_blk
+    virtio_net
+    EOF
+    ```
+
+2. Regenerate the initramfs:
+
+    ```bash
+    update-initramfs -u
+    ```
+
+### 5. Reboot and Verify
+
+1. **Exit the chroot environment**:
+
+    ```bash
+    exit
+    ```
+
+2. **Reboot the VM**:
+
+    ```bash
+    reboot
+    ```
+
+3. **Verify Boot and Network Connectivity**:
     - Confirm that the VM boots successfully and that network connectivity is functional via the `virtio` NIC.
 
 ## Troubleshooting
@@ -111,8 +219,3 @@ This guide explains how to import Redhat/CentOS based virtual machines from othe
 !!! question "Need Help?"
     If you have any questions or encounter issues while importing a VM, please reach out to our support team for assistance.
 
----
-
-!!! note "Document Information"
-     - Last Updated: 2024-09-09
-     - VergeOS Version: 4.12.6


### PR DESCRIPTION
## Summary

- Broadens the RHEL/CentOS import guide to cover SUSE, openSUSE, Debian, and Ubuntu
- Adds detailed instructions for mounting root filesystem and chrooting during rescue mode
- Adds Debian/Ubuntu alternative using `update-initramfs` instead of dracut

## Changes

- **Title expanded**: Now covers RHEL, CentOS, SUSE, Debian, Ubuntu
- **SUSE tip added**: Boot from installation ISO when GRUB rescue fails
- **New Section 3**: Mount root filesystem and chroot (finding partitions, LVM, binding virtual filesystems)
- **Debian/Ubuntu support**: Alternative using `update-initramfs` instead of dracut
- **virtio_pci driver**: Added to both dracut and initramfs-tools configurations
- **Tags updated**: Added rhel, centos, suse, debian, ubuntu, dracut, initramfs
- **Removed**: Document Information footer

Fixes #177

## Test plan

- [ ] Preview the rendered markdown locally with `mkdocs serve`
- [ ] Verify all code blocks render correctly
- [ ] Confirm admonitions display properly

🤖 Generated with [Claude Code](https://claude.ai/code)