### PR TITLE
📝 docs: update vSAN navigation path in node removal guide

### DIFF
--- a/docs/knowledge-base/posts/node-removal.md
+++ b/docs/knowledge-base/posts/node-removal.md
@@ -60,7 +60,7 @@ Before powering off the node, all drives must be removed from the vSAN.
 ### Step 3: Power Off the Node
 
 !!! danger "Verify vSAN Health Before Proceeding"
-    Before powering off the node, navigate to **System** > **vSAN** and confirm all tiers are **green** (healthy). Do not proceed until the vSAN has fully recovered from the drive removal in Step 2.
+    Before powering off the node, navigate to **Infrastructure** > **vSAN Tiers** and confirm all tiers are **green** (healthy). Do not proceed until the vSAN has fully recovered from the drive removal in Step 2.
 
 1. Once all drives are deleted and the node status shows **Maintenance Mode**, click **Power Off** on the left menu.
 2. Click **Yes** to confirm.


### PR DESCRIPTION
## Summary
- Updates the vSAN health check navigation path from "System > vSAN" to "Infrastructure > vSAN Tiers" to match the current VergeOS UI

## Test plan
- [x] Verify the navigation path matches the current UI
- [x] Review the rendered documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)