### PR TITLE
Add 26.1 release notes

### DIFF
--- a/docs/release-notes/26-0-release-notes.md
+++ b/docs/release-notes/26-0-release-notes.md
@@ -3,7 +3,7 @@
 !!! info "Release Information"
     - **Release Date**: October 2025
     - **Latest Version**: 26.0.2.2 (December 2025)
-    - **Status**: Latest Production Release
+    - **Status**: Supported
     - **End-of-Life**: TBD
 
 ## Major Features & Themes

--- a/docs/release-notes/26-1-release-notes.md
+++ b/docs/release-notes/26-1-release-notes.md
@@ -1,0 +1,176 @@
+# 26.1 Release Notes
+
+!!! info "Release Information"
+    - **Release Date**: January 2026
+    - **Latest Version**: 26.1.1 (January 2026)
+    - **Status**: Latest Production Release
+    - **End-of-Life**: TBD
+
+## Major Features & Themes
+
+### Partial Snapshots
+
+!!! success "Tag-Based Snapshot Control"
+    - Create snapshots that include or exclude resources based on tags
+    - Supports virtual machines, tenants, and NAS services
+    - Control quiescing behavior per tagged resource
+    - Full sync support for partial snapshots
+
+### Performance Improvements
+
+!!! benchmark "Storage & System Performance"
+    - Disk repair performance improved by approximately 4x
+    - Faster controller walk times after reboot
+    - Improved sync performance with cross-directory file threading
+    - Enhanced storage cache usage for database on controller nodes
+    - Faster node start times through CPU type property caching
+
+## 26.1.1 (January 2026)
+
+### New Features
+
+#### Partial Snapshots
+- Added partial snapshot support using tags for include or exclude filtering
+- Supports virtual machines, tenants, and NAS services
+- Control which resources are quiesced during partial snapshots
+- Partial snapshot settings now displayed in edit view
+- Multiple tags properly displayed in snapshot list view
+
+#### Site Syncs & Backup
+- Added sync support for partial snapshots
+- Enhanced sync audit logging with status, progress, and failure details
+- Added synclist to outgoing sync logs
+
+#### Task Automation
+- Added task support helpers for auto sync creation and configuration
+- Added task execute and profile period links to sync dashboard
+- New task creation confirmation helper for auto-syncs
+- Multiple task UI enhancements
+
+### Functionality Changes & Improvements
+
+#### Virtual Machines
+- VM Export now supports tags in ybvm files
+- Added OVF export output support
+- VM snapshot drives now inherit a generated UUID from the source drive
+- Added advanced options for video card devices (e.g., `vga.virtio.X`, `vga.std.X`, `vga.vmware.X`)
+- "Auto" is now the default selection on migration popups (VMs, service containers, tenant nodes, VMware containers)
+
+#### User Interface
+- Added password visibility toggle for user creation and login forms
+- Changed millisecond displays to friendlier format (cluster tiers, vnet dashboard, VM paste configs)
+- Added members link to tag picker
+- Breadcrumb enhancements for viewing system snapshots from volumes/VMs
+- Renamed remaining "Media Images" references to "Files"
+- Cleaned up cluster dashboard display when compute is disabled
+
+#### Storage & vSAN
+- Added ability to specify vDisk vendor via advanced system setting (inherits to tenants)
+- Cluster tiers now show progress even at 0% when status is working
+
+#### Networking & Syncs
+- Removed password confirmation requirement on remote repositories
+- Added ability to specify HTTP method and append to URL for webhooks
+
+#### NAS
+- Antivirus is now disabled by default for new NAS services
+
+#### GPU Support
+- Added NVIDIA GRID vGPU drivers 19.4, 18.6, and 16.13
+
+### Operating System & Performance
+
+#### Core System
+- Updated QEMU to 10.0.7
+- Added bash completion for `jvcmd`
+- Sped up node start times by caching best CPU type properties
+
+#### vSAN Performance
+- Improved performance when hundreds of VMs run in the same tenant
+- Improved storage cache usage for database on controller nodes
+- Improved disk repair performance by approximately 4x (parallel repairs, defaults to 4 threads)
+- Improved initial controller walk time after reboot
+- Improved sync performance with cross-directory file threading
+- Implemented readahead for full walks when cache memory is limited
+
+### Bug Fixes
+
+#### Snapshots & Restore
+- Fixed immutable snapshots not syncing properly to backup sites
+- Fixed NAS Service VMs not retaining tags when restored from snapshots
+- Fixed restoring NAS Service VMs from partial snapshots
+- Fixed manually synced system snapshots using incorrect prefix on destination
+- Fixed "Never Expires" option leaving calendar selector visible on form
+
+#### Site Syncs
+- Fixed offline site cards showing as online without branding logo
+- Fixed enable/disable dialog and tooltip issues on outgoing sync dashboard
+- Fixed left navigation menu options (Delete, Disable, Enable) not working for outgoing syncs
+- Added stats logging for paused/disabled/error syncs
+- Fixed refresh errors occurring on backup site during incoming syncs
+
+#### Authentication & Users
+- Fixed password change loop when using TOTP 2FA with required password change
+- Fixed password confirmation mismatch being accepted when 2FA is enabled
+- Fixed 2FA email when password change is required
+
+#### Virtual Machines
+- Fixed VM service cloning not copying export settings and data
+- Fixed "New Virtual Machine" page proceeding with selection instead of searching when pressing Enter
+- Fixed cloud-init variable not being set for cluster name
+- Fixed downloading VM recipes when Cloudflare is unavailable
+
+#### Storage & vSAN
+- Fixed adding storage to compute node causing incorrect drive distribution for first 2 drives
+- Fixed vSAN crash when recreating a tier that was deleted before upgrading to version 26
+- Fixed SMBIOS manufacturer and disk vendor not passing to tenants
+- Fixed previous regression affecting Storware backup integration
+
+#### User Interface
+- Fixed product help links broken or incorrect on multiple dashboards
+- Fixed VM NIC "Add IP Address" breadcrumb navigation
+- Fixed VMware backup VM page not refreshing during backup
+- Fixed link to LLDP neighbors from node NICs
+- Fixed cluster tier dashboard not showing all nodes
+- Fixed incorrect verbiage on NIC asset field note (mentioned drive instead of NIC)
+- Fixed JavaScript error when modifying IPSec Phase 1 configurations
+- Fixed issue recovering large number of objects simultaneously from system snapshot
+
+#### Certificates
+- Fixed duplicate certificates being created with new systems
+- Cleaned up duplicate verge-api self-signed certificates
+- Fixed certificates that included IP addresses
+- Automatic cleanup of duplicate certificates when upgrading to 26.1
+
+#### Installation
+- Fixed installing encrypted vSAN on second controller node
+- Removed EFI question unless using advanced installer
+- Fixed installer allowing overwrite of vSAN encryption key disk as boot-only
+
+#### Other Fixes
+- Fixed Swagger documentation for fields pointing to '*' table row type
+- Fixed SMTP widget email field on forms
+- Fixed issue where update completion logged "idle" status twice
+- Fixed AI Workspace file uploads showing 0% then disappearing
+- Fixed general file uploads staying at 0% after refresh
+
+---
+
+## Upgrade Notes
+
+!!! warning "Important Upgrade Information"
+    - **Reboot Required**: Yes - all nodes will require restart
+    - **Certificate Cleanup**: Duplicate certificates are automatically cleaned up during upgrade
+    - **NAS Antivirus**: New NAS services have antivirus disabled by default; existing services unchanged
+    - **Partial Snapshots**: New feature requires tagging resources before creating partial snapshots
+
+!!! info "Post-Upgrade Actions"
+    - Review and configure partial snapshot profiles if tag-based backups are desired
+    - Verify sync configurations after upgrade
+
+## Known Issues
+
+!!! note "Current Limitations"
+    - Partial snapshots cannot be used for full system restore; use for individual resource recovery or syncs only
+
+---

--- a/docs/release-notes/4-12-release-notes.md
+++ b/docs/release-notes/4-12-release-notes.md
@@ -1,6 +1,7 @@
 ---
 description: Release notes for the 4.12 series of VergeOS
 #icon: material/text-box-outline
+status: deprecated
 ---
 
 # 4.12 Release Notes
@@ -8,8 +9,8 @@ description: Release notes for the 4.12 series of VergeOS
 !!! info "Series Information"
     - **Initial Release**: February 2024 (4.12.0)
     - **Latest Version**: 4.12.6 (July 2024)
-    - **Status**: Supported (Superseded by 4.13)
-    - **End-of-Life**: TBD
+    - **Status**: Deprecated
+    - **End-of-Life**: January 2026
 
 ## Major Features & Themes
 
@@ -444,4 +445,3 @@ Over 50 additional minor fixes and enhancements were also included in this relea
 - Fixed hostname validation for NAS
 - Improved BGP functionality
 - Various minor performance and stability improvements
-

--- a/docs/release-notes/release-notes-overview.md
+++ b/docs/release-notes/release-notes-overview.md
@@ -11,9 +11,10 @@ Welcome to the VergeOS Release Notes. This section provides information about ea
 
 | Release | Initial Release | Latest Version | Status | End-of-Life |
 |--------|----------------|----------------|---------|-------------|
-| [26.0](release-notes.md) | October 2025 | 26.0.2.2 (December 2025) | Latest | TBD |
+| [26.1](26-1-release-notes.md) | January 2026 | 26.1.1 (January 2026) | Latest | TBD |
+| [26.0](26-0-release-notes.md) | October 2025 | 26.0.2.2 (December 2025) | Supported | TBD |
 | [4.13](4-13-release-notes.md) | November 2024 | 4.13.4.2 (August 2025) | Supported | TBD |
-| [4.12](4-12-release-notes.md) | February 2024 | 4.12.6 (July 2024) | Supported | TBD |
+| [4.12](4-12-release-notes.md) | February 2024 | 4.12.6 (July 2024) | Deprecated | January 2026 |
 | [4.11](4-11-release-notes.md) | February 2023 | 4.11.4.3 (January 2024) | Deprecated | December 2024 |
 | [4.10](4-10-release-notes.md) | June 2022 | 4.10.3.1 (January 2023) | Deprecated | June 2024 |
 | [4.9](4-9-release-notes.md) | October 2021 | 4.9.2 (February 2022) | Deprecated | February 2023 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -353,9 +353,10 @@ nav:
       - Prometheus Exporter: product-guide/tools-integrations/prometheus-exporter.md
       - Storware Backup and Recovery: product-guide/tools-integrations/storware-backup-recovery.md
       - Terraform Provider: product-guide/tools-integrations/terraform-provider.md
-  - Release Notes: 
+  - Release Notes:
     - Overview: release-notes/release-notes-overview.md
-    - 26.0 (latest): release-notes/release-notes.md
+    - 26.1 (latest): release-notes/26-1-release-notes.md
+    - "26.0": release-notes/26-0-release-notes.md
     - 4.13: release-notes/4-13-release-notes.md
     - 4.12: release-notes/4-12-release-notes.md
     - 4.11: release-notes/4-11-release-notes.md


### PR DESCRIPTION
## Summary
- Add 26.1.1 release notes documenting partial snapshots, performance improvements, and bug fixes
- Rename 26.0 release notes file for naming consistency (`release-notes.md` → `26-0-release-notes.md`)
- Update release notes overview to show 26.1 as latest release
- Mark 4.12 as deprecated with January 2026 end-of-life
- Update navigation in mkdocs.yml

## Test plan
- [x] Verify 26.1 release notes render correctly
- [x] Verify 26.0 release notes link works after rename
- [x] Verify release notes overview table displays correctly
- [x] Verify navigation sidebar links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)