### PR TITLE
Clarify drive replacement for failed vs working drives

### DIFF
--- a/docs/product-guide/operations/drive-replacement.md
+++ b/docs/product-guide/operations/drive-replacement.md
@@ -20,9 +20,22 @@ The VergeOS interface will provide warnings or alerts to indicate when there is 
 - **Warning** - Wear level exceeded maximum threshold(s)
 - **Warning** - Reallocated sectors exceeded maximum threshold(s)
 - **Error** - Drive is unresponsive; read or write error threshold reached
+- **Missing** - Drive is no longer detected by the system (failed or physically removed)
 
 !!! warning "Important"
     **It is highly recommended to configure on-demand and scheduled subscriptions (with *target type=system Dashboard*) to ensure timely awareness of drive issues.** The [Creating Subscriptions Guide](/product-guide/system/subscriptions-overview) provides information about setting up subscriptions.
+
+## Which Replacement Procedure Should I Use?
+
+The replacement procedure depends on the current state of the drive:
+
+| Drive Status | Condition | Procedure |
+|--------------|-----------|-----------|
+| **Missing** or **Error** (unresponsive) | Drive has already failed and is not responding | [Scenario 1: Replace a Failed/Missing Drive](#scenario-1-replace-a-failedmissing-drive) |
+| **Warning** or **Degraded** | Drive is still operational but showing signs of failure | [Scenario 2: Proactively Replace a Working Drive](#scenario-2-proactively-replace-a-working-drive) |
+
+!!! tip "How to Tell if a Drive is Missing"
+    A missing drive will show a status of **Missing** in the drive list. This occurs when the drive has completely failed, lost connection, or has already been physically removed. The drive entry remains in the UI to allow you to initiate the replacement process.
 
 ## Determine Correct Physical Drive for Replacement
 
@@ -44,7 +57,32 @@ The VergeOS interface will provide warnings or alerts to indicate when there is 
 
 ![diag-ledoff.png](/product-guide/screenshots/diag-ledoff.png)
 
-## Replace a Drive
+## Scenario 1: Replace a Failed/Missing Drive
+
+Use this procedure when a drive has already failed and is no longer responding, or when the drive shows a **Missing** status in the UI.
+
+!!! danger "**CAUTION: Before** initiating a drive repair operation, **verify**:"
+    1. The node that contains the failed drive will need to be placed into maintenance mode. All other nodes should be online and fully operational (i.e. not in maintenance mode or offline).
+    2. No other drive repairs are running on different nodes within the same storage tier *(Drive repairs on the same physical node are acceptable)*
+
+1. **Place the node** that has the failed drive **into Maintenance Mode**.
+2. If the failed drive is still physically present, **remove it** from the node. Use the [LED activation process](#determine-correct-physical-drive-for-replacement) if needed to identify the correct drive.
+3. **Insert the replacement drive** into the same slot (or any available slot).
+4. **Wait** for the new drive to be detected by the system.
+5. From the node dashboard, click **Drives**.
+6. Click to **select the failed/missing drive entry** in the list (the old drive that needs replacement).
+7. Click **Replace Drive** on the left menu.
+8. In the dialog that appears, **select the new drive** from the list of available drives.
+9. Click **Submit** to confirm the replacement.
+
+!!! success
+    The system will automatically format and initialize the new drive, then begin the repair process. The drive status will change to "Repairing" and the dashboard will show an **Estimated Repair Completion date and time.**
+
+---
+
+## Scenario 2: Proactively Replace a Working Drive
+
+Use this procedure when a drive is still operational but showing warning signs (such as wear level warnings or reallocated sectors) and you want to replace it before it fails completely.
 
 !!! danger "**CAUTION: Before** initiating a drive repair operation, **verify**:"
     1. The node that the drive to be replaced resides on will need to be placed into maintenance mode. All other nodes should be online and fully operational (i.e. not in maintenance mode or offline).
@@ -66,6 +104,21 @@ The VergeOS interface will provide warnings or alerts to indicate when there is 
 !!! success
     After the vSAN has completed a full walk, the repair process will begin, and the drive status will change to "Repairing"; at this point the drive dashboard will indicate an **Estimated Repair Completion date and time.**
 
-!!! warning "**DURING THE REPAIR PROCESS:**"  
+---
+
+## During the Repair Process
+
+!!! warning "Important"
+    The following applies to **both** replacement scenarios:
+
     - **Do NOT restart, reset or power off any nodes** until the drive shows a status of "Online"; it is important that all other nodes remain fully operational during the repair process.
     - **Additional drive replace/repair operations should NOT be initiated until this repair operation has fully completed** unless the additional drive resides: within the same node - OR - on another storage tier.
+
+## Troubleshooting
+
+If the **Replace Drive** option is not working or the replacement process fails:
+
+1. **Reboot the node** - This can help the system properly detect the new drive and clear any stale state.
+2. **Verify drive compatibility** - Ensure the replacement drive meets the same specifications as the original (capacity, interface type).
+3. **Check drive seating** - Ensure the new drive is properly seated in the slot.
+4. **Contact support** - If issues persist after a node reboot, contact VergeOS support for assistance.


### PR DESCRIPTION
## Summary

- Adds separate procedures for replacing failed/missing drives vs proactively replacing working drives
- Documents the "Replace Drive" UI action for failed drives (simpler workflow)
- Adds decision table to help users choose the correct procedure based on drive status
- Adds troubleshooting section with guidance when Replace Drive doesn't work

## Test plan

- [ ] Preview the updated drive replacement page
- [ ] Verify internal links work correctly
- [ ] Confirm decision table renders properly

Fixes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)