### PR TITLE
Remove outdated 30-Day Trial (POC) recipe reference

### DIFF
--- a/docs/product-guide/automation/tenant-recipes.md
+++ b/docs/product-guide/automation/tenant-recipes.md
@@ -65,9 +65,6 @@ Some question types allow you to lookup database information or create/edit data
 
 The *Database Context* field allows you to choose to interact with the local database (the parent system) or the database of the newly-created tenant.  This applies to question types: *Database Create, Database Edit, and Database Find*.
 
-!!! tip "**Reference Example**"
-    The "***30-Day Trial (POC)***", shared to your tenant recipes by default, provides an example of some of the things that can be done with a tenant recipe. Although it cannot be directly edited, you can clone this recipe to view the question configuration as a reference.
-
 ## Modify a Recipe
 
 When any changes are made to a recipe, it will need to be republished in order to make those changes available.  The top of the recipe dashboard will display a message indicating that it must be republished for changes to take effect.  You can use the **Republish** link within this message or click Republish on the left menu.


### PR DESCRIPTION
## Summary

- Remove the "Reference Example" admonition from the Tenant Recipes page that referenced the "30-Day Trial (POC)" recipe, which was removed in VergeOS 26.0

## Context

- The 26.0 release notes confirm: *"Removed 30-day POC tenant recipe (no longer maintained)"*
- Validated against a live **VergeOS 26.1.2** system — Tenant Recipes page shows zero results, confirming the recipe is gone
- The "Tenant Crash Cart" recipe (suggested as a replacement in the issue) is a **VM Recipe**, not a Tenant Recipe, so it would not be an appropriate substitute reference

## Test plan

- [ ] Verify the tenant recipes page renders correctly at `/product-guide/automation/tenant-recipes/`
- [ ] Confirm the Database Context section flows naturally into the "Modify a Recipe" section

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)