### PR TITLE
Replace v25 references with 26.0

### DIFF
--- a/docs/product-guide/system/themes.md
+++ b/docs/product-guide/system/themes.md
@@ -22,7 +22,6 @@ You'll understand:
 
 **Environment Setup:**
 
-- VergeOS v25.2.0 or later (Theme functionality introduced in this version)
 - Administrative access (Cluster Admin or Tenant Admin permissions)
 
 **Background Knowledge:**
@@ -157,9 +156,6 @@ Manages the top header bar and its components including buttons, navigation elem
 Controls fundamental interface elements including overall backgrounds, card components, borders, and primary text colors. These properties establish the foundation visual appearance that other components build upon.
 
 ## Integration with Existing Branding
-
-### Relationship to UI Branding
-The Theme functionality introduced in VergeOS v25.2.0 represents an evolution from the previous UI Branding system. What was formerly called "UI Branding" in earlier versions has been enhanced and rebranded as the "Theme" system, providing expanded customization capabilities beyond the original branding features.
 
 ### Asset Integration
 Custom logos and favicons uploaded through the Theme system integrate with the color schemes to provide complete visual customization. Assets maintain their quality and positioning while adapting to the chosen color palette.

--- a/docs/product-guide/tenants/layer-2-networks.md
+++ b/docs/product-guide/tenants/layer-2-networks.md
@@ -1,6 +1,6 @@
 ---
 requirements:
-  vergeos_version: "v25.2 or later"
+  vergeos_version: "26.0 or later"
   access_levels: ["Cluster Admin"]
   background_knowledge: ["Networking fundamentals", "VLAN concepts", "Tenant management"]
 
@@ -113,7 +113,7 @@ Tenant Layer 2 Networks are ideal for scenarios requiring:
 | Feature | Tenant Layer 2 Networks | Virtual Switch Ports |
 |---------|-------------------------|---------------|
 | Configuration Complexity | Simple - single UI action | More complex - multiple steps |
-| Supported VergeOS Version | v25.2 or later | All versions |
+| Supported VergeOS Version | 26.0 or later | All versions |
 | Automatic Network Creation | Yes | No - manual configuration required |
 | VLAN Trunking Support | Single VLAN per configuration | Can trunk multiple VLANs |
 | Typical Use Case | Single VLAN pass-through | Complex multi-VLAN scenarios |

--- a/docs/release-notes/4-13-release-notes.md
+++ b/docs/release-notes/4-13-release-notes.md
@@ -63,11 +63,11 @@ description: Release notes for the 4.13 series of VergeOS
 ## 4.13.4.1 (August 2025)
 
 !!! info "Hotfix Release"
-    No reboot required (if System is currently on 4.13.x). Required update for our upcoming major release where we're moving to a different versioning system. Future updates will start with the last two digits of the year, followed by the quarter the development work started in on that release. i.e. 25.2
+    No reboot required (if System is currently on 4.13.x). Required update for our upcoming major release where we're moving to a different versioning system. Future updates will start with the last two digits of the year, followed by the quarter the development work started in on that release. i.e. 26.0
 
 #### Bug Fixes
 * Fixed two-factor authentication issues affecting TOTP authentication methods
-* Enhanced UI version handling in preparation for the 25.2 release
+* Enhanced UI version handling in preparation for the 26.0 release
 * Various system stability improvements
 
 ## 4.13.4 (March 2025)


### PR DESCRIPTION
## Summary
- Replaced incorrect "v25.2" version references with "26.0" across documentation
- Removed unnecessary version prerequisite and UI Branding evolution section from themes guide
- Updated release notes to reflect correct version numbering

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)