### PR TITLE
Add L2 tenant network creation details and removal process

### DIFF
--- a/docs/product-guide/tenants/layer-2-networks.md
+++ b/docs/product-guide/tenants/layer-2-networks.md
@@ -104,6 +104,9 @@ When you create a Tenant Layer 2 Network, VergeOS automatically provisions the f
 !!! info "Understanding These Components"
     All three components are created automatically and work together to provide Layer 2 connectivity. If you later remove the Tenant Layer 2 Network from the host side, the NIC is automatically removed, but the Physical and External networks inside the tenant must be cleaned up manually. See [Removing a Tenant Layer 2 Network](#removing-a-tenant-layer-2-network) for details.
 
+!!! warning "Do Not Tag the External Network"
+    The External Network created inside the tenant will not have a VLAN tag on it. The interface is already tagged for this VLAN. Leave this network **untagged**. Adding a VLAN tag to the tenant-side External Network is a common misconfiguration that will break connectivity.
+
 Tenant virtual machines can attach NICs to these networks to gain direct access to the passed-through VLAN.
 
 ### Use Cases


### PR DESCRIPTION
## Summary

- Documents what gets created when sharing a Layer 2 network to a tenant (NIC on tenant node, Physical network, External network)
- Adds step-by-step removal/deletion process with correct ordering
- Corrects navigation paths to match actual UI

Closes #405

## Validation Results

Tested the full create → verify → disable → delete → cleanup lifecycle on a live VergeOS 26.1.3 system with a root host and a single-node tenant.

### Creation

| What was tested | Result |
|---|---|
| Creating L2 network adds NIC to tenant node | Node NICs: 1 → **2** |
| Creates Physical network in tenant | `Physical - <network-name>` appeared (Stopped) |
| Creates External network in tenant | `<network-name>` appeared (Stopped) |

### Removal

| What was tested | Result |
|---|---|
| Disable → Delete flow from host side | Completed without errors when following correct order |
| NIC auto-removed on host-side delete | Node NICs: 2 → **1** (automatically cleaned up) |
| Tenant-side networks remain after host-side delete | Both orphaned networks persisted — manual cleanup required |
| Deletion order matters inside tenant | Deleting Physical network before External fails with "another network is referencing this as an interface network" error |

### Key Findings That Informed Doc Changes

1. **NIC is auto-removed** — The issue suggested all three tenant-side components need manual cleanup, but testing showed the NIC on the tenant node is automatically removed when the L2 network is disabled/deleted from the host side. Only the two networks (External and Physical) require manual cleanup.
2. **Deletion order matters** — The External network must be deleted before the Physical network inside the tenant, because the External references the Physical as its interface network.
3. **Navigation path corrected** — The actual UI path is **Network > Layer2 Networks** in the left sidebar (expandable menu), not a top-level "Networks" link.
4. **Disable/Delete uses row selection** — The workflow is: select checkbox → click Disable/Delete in sidebar (not an edit form toggle as originally drafted).

## Test plan

- [ ] Verify `mkdocs serve` renders the updated page without errors
- [ ] Review the "Automatic Network Creation" section for accuracy
- [ ] Review the "Removing a Tenant Layer 2 Network" section for accuracy
- [ ] Confirm navigation instructions match the VergeOS 26.x UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)