### PR TITLE
Add frontmatter validation CI check and update docs

### DIFF
--- a/.github/scripts/validate_frontmatter.py
+++ b/.github/scripts/validate_frontmatter.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Validate that all documentation Markdown files have YAML frontmatter.
+
+Frontmatter is the YAML block between --- delimiters at the top of a file.
+At minimum, every doc must have a `title` and `description` field.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Files and directories excluded from frontmatter requirements
+EXCLUDE_PATHS = {
+    "docs/index.md",
+    "docs/support.md",
+    "docs/how-to-write-a-verge-guide.md",
+    "docs/knowledge-base/template.md",
+    "docs/knowledge-base/index.md",
+}
+
+EXCLUDE_DIRS = {
+    "docs/overrides",
+    "docs/stylesheets",
+    "docs/javascripts",
+    "docs/assets",
+}
+
+# Fields required in all frontmatter
+REQUIRED_FIELDS = {"title", "description"}
+
+# Additional fields required for knowledge base articles
+KB_REQUIRED_FIELDS = {"title", "slug", "description", "date", "tags", "categories"}
+
+
+def parse_frontmatter(content: str) -> dict | None:
+    """Extract frontmatter fields from file content. Returns None if no frontmatter."""
+    if not content.startswith("---"):
+        return None
+
+    match = re.match(r"^---\s*\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        return None
+
+    fields = {}
+    for line in match.group(1).splitlines():
+        key_match = re.match(r"^(\w[\w_-]*)\s*:", line)
+        if key_match:
+            fields[key_match.group(1)] = True
+
+    return fields
+
+
+def should_check(file_path: Path, repo_root: Path) -> bool:
+    """Determine if a file should be checked for frontmatter."""
+    relative = str(file_path.relative_to(repo_root))
+
+    if relative in EXCLUDE_PATHS:
+        return False
+
+    for exclude_dir in EXCLUDE_DIRS:
+        if relative.startswith(exclude_dir):
+            return False
+
+    return True
+
+
+def is_kb_article(file_path: Path, repo_root: Path) -> bool:
+    """Check if a file is a knowledge base article."""
+    relative = str(file_path.relative_to(repo_root))
+    return relative.startswith("docs/knowledge-base/posts/")
+
+
+def validate_file(file_path: Path, repo_root: Path) -> list[str]:
+    """Validate frontmatter for a single file. Returns list of error messages."""
+    errors = []
+    relative = str(file_path.relative_to(repo_root))
+    content = file_path.read_text(encoding="utf-8")
+
+    fields = parse_frontmatter(content)
+
+    if fields is None:
+        errors.append(f"  {relative}: missing frontmatter")
+        return errors
+
+    required = KB_REQUIRED_FIELDS if is_kb_article(file_path, repo_root) else REQUIRED_FIELDS
+
+    missing = required - set(fields.keys())
+    if missing:
+        errors.append(f"  {relative}: missing required fields: {', '.join(sorted(missing))}")
+
+    return errors
+
+
+def main():
+    repo_root = Path(__file__).parent.parent.parent
+    docs_dir = repo_root / "docs"
+
+    if not docs_dir.exists():
+        print(f"Error: {docs_dir} not found")
+        sys.exit(1)
+
+    all_errors = []
+
+    for md_file in sorted(docs_dir.rglob("*.md")):
+        if not should_check(md_file, repo_root):
+            continue
+        all_errors.extend(validate_file(md_file, repo_root))
+
+    if all_errors:
+        print("ERROR: Frontmatter validation failed:")
+        print("=" * 70)
+        for error in all_errors:
+            print(error)
+        print("=" * 70)
+        print(f"Found {len(all_errors)} file(s) with missing or incomplete frontmatter.")
+        print()
+        print("Every documentation file needs YAML frontmatter with at least:")
+        print("  title, description")
+        print()
+        print("Knowledge base articles additionally require:")
+        print("  slug, date, tags, categories")
+        sys.exit(1)
+    else:
+        print(f"All documentation files have valid frontmatter.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/validate_frontmatter.py
+++ b/.github/scripts/validate_frontmatter.py
@@ -13,8 +13,6 @@ from pathlib import Path
 # Files and directories excluded from frontmatter requirements
 EXCLUDE_PATHS = {
     "docs/index.md",
-    "docs/support.md",
-    "docs/how-to-write-a-verge-guide.md",
     "docs/knowledge-base/template.md",
     "docs/knowledge-base/index.md",
 }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,21 @@ on:
       - main
 
 jobs:
+  frontmatter:
+    name: Validate Frontmatter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Validate frontmatter
+        run: python .github/scripts/validate_frontmatter.py
+
   widget-links:
     name: Validate Widget Links
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,37 @@ mkdocs build --site-dir ./_site
 - **Knowledge Base:** Step-by-step articles in `docs/knowledge-base/posts/`
 - **Implementation Guide:** Installation and deployment procedures
 
-### Knowledge Base Article Template
+### Frontmatter
 
-All KB articles use frontmatter:
+All documentation files require YAML frontmatter. CI enforces this on every PR.
+
+#### Product Guide / Implementation Guide / Reference Architecture
+
+At minimum, `title` and `description` are required:
+
+```yaml
+---
+title: "Page Title"
+description: "Brief description of the page content."
+semantic_keywords:
+  - "natural language search phrase"
+use_cases:
+  - use_case_identifier
+tags:
+  - tag1
+  - tag2
+categories:
+  - Category Name
+---
+```
+
+- `semantic_keywords` — natural-language phrases for AI/vector search
+- `use_cases` — machine-readable identifiers for intent matching
+- `tags` / `categories` — topic filtering and discovery
+
+#### Knowledge Base Articles
+
+KB articles in `docs/knowledge-base/posts/` have additional required fields (`slug`, `date`, `tags`, `categories`):
 
 ```yaml
 ---
@@ -72,11 +100,13 @@ title: [Article Title]
 slug: [url-friendly-title]
 description: [Brief description]
 author: [Author Name]
-published: true
+draft: false
 date: YYYY-MM-DD
 tags: [tag1, tag2, tag3]
 categories:
   - [Category]
+editor: markdown
+dateCreated: YYYY-MM-DD
 ---
 ```
 
@@ -123,6 +153,7 @@ Site navigation is defined in `mkdocs.yml` under `nav:`. The structure mirrors t
 - **Trigger:** Push to `main` branch
 - **Build:** `mkdocs build` with Material Insiders theme
 - **Deploy:** GitHub Pages via `deploy-pages` action
+- **PR Checks:** Frontmatter validation, widget link validation, internal link checking
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -135,23 +135,75 @@ Supported types: `note`, `abstract`, `info`, `tip`, `success`, `question`, `warn
 - Use relative paths: `![Alt text](../assets/image.png)`
 - Glightbox plugin enables click-to-zoom
 
-### Knowledge Base Articles
+### Frontmatter
 
-KB articles require YAML frontmatter:
+All documentation files require YAML frontmatter. A CI check enforces this on every pull request.
+
+#### Product Guide / Implementation Guide / Reference Architecture
+
+At minimum, every page needs `title` and `description`:
 
 ```yaml
 ---
-title: Article Title
-slug: url-friendly-title
-description: Brief description
-author: Author Name
-published: true
-date: YYYY-MM-DD
-tags: [tag1, tag2]
+title: "Page Title"
+description: "Brief description of the page content."
+semantic_keywords:
+  - "search phrase one"
+  - "search phrase two"
+use_cases:
+  - use_case_one
+  - use_case_two
+tags:
+  - tag1
+  - tag2
 categories:
-  - Category
+  - Category Name
 ---
 ```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `title` | Yes | Page title |
+| `description` | Yes | Brief summary used for SEO and search |
+| `semantic_keywords` | No | Natural-language search phrases for AI/vector search |
+| `use_cases` | No | Machine-readable use case identifiers |
+| `tags` | No | Topic tags for filtering and discovery |
+| `categories` | No | Broad category grouping |
+
+#### Knowledge Base Articles
+
+KB articles in `docs/knowledge-base/posts/` have additional required fields:
+
+```yaml
+---
+title: "Article Title"
+slug: url-friendly-title
+description: "Brief description"
+author: Author Name
+draft: false
+date: 2025-01-15
+tags:
+  - tag1
+  - tag2
+categories:
+  - Category
+editor: markdown
+dateCreated: 2025-01-15
+---
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `title` | Yes | Article title |
+| `slug` | Yes | URL-friendly identifier |
+| `description` | Yes | Brief summary |
+| `date` | Yes | Last updated date |
+| `tags` | Yes | Topic tags |
+| `categories` | Yes | Article categories |
+| `author` | No | Author name |
+| `draft` | No | Set `true` to hide from published site |
+| `editor` | No | Editor format (typically `markdown`) |
+| `dateCreated` | No | Original creation date |
 
 ## Resources
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,6 +1,21 @@
 ---
 title: "Glossary of Key Terms"
 description: "Definitions of key terms and concepts used throughout VergeOS documentation, including networking, storage, virtualization, and multi-tenancy terminology."
+semantic_keywords:
+  - "VergeOS glossary terms definitions terminology"
+  - "virtualization networking storage multi-tenancy concepts"
+  - "VergeOS platform vocabulary key terms reference"
+use_cases:
+  - lookup_terminology
+  - onboarding_new_users
+  - reference_definitions
+tags:
+  - glossary
+  - terminology
+  - reference
+  - definitions
+categories:
+  - Getting Started
 ---
 
 # Glossary of Key Terms

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,3 +1,8 @@
+---
+title: "Glossary of Key Terms"
+description: "Definitions of key terms and concepts used throughout VergeOS documentation, including networking, storage, virtualization, and multi-tenancy terminology."
+---
+
 # Glossary of Key Terms
 
 ## A

--- a/docs/how-to-write-a-verge-guide.md
+++ b/docs/how-to-write-a-verge-guide.md
@@ -1,6 +1,24 @@
 ---
 title: "How to Write a VergeOS Guide"
 description: "Style guide for writing VergeOS documentation, covering structure, formatting, Markdown features, and the publication process."
+semantic_keywords:
+  - "VergeOS documentation writing style guide conventions"
+  - "Markdown formatting admonitions MkDocs Material syntax"
+  - "guide structure steps overview prerequisites best practices"
+  - "documentation contribution review publishing process"
+use_cases:
+  - write_new_documentation
+  - follow_style_conventions
+  - format_markdown_content
+  - structure_guide_steps
+tags:
+  - documentation
+  - style-guide
+  - writing
+  - markdown
+  - contributing
+categories:
+  - Best Practices
 ---
 
 ## 1. Overview

--- a/docs/how-to-write-a-verge-guide.md
+++ b/docs/how-to-write-a-verge-guide.md
@@ -1,3 +1,8 @@
+---
+title: "How to Write a VergeOS Guide"
+description: "Style guide for writing VergeOS documentation, covering structure, formatting, Markdown features, and the publication process."
+---
+
 ## 1. Overview
 
 In this guide, you will learn how to write content for vergeOS and reach a wide audience of both beginner and advanced users such as developers and system administrators.

--- a/docs/reference-architecture/csp.md
+++ b/docs/reference-architecture/csp.md
@@ -1,3 +1,8 @@
+---
+title: "Multi-tenant Deployments"
+description: "Reference architecture for Cloud Service Providers deploying VergeOS as a multi-tenant IaaS platform with tenant isolation, resource allocation, and scalable infrastructure."
+---
+
 # Multi-tenant Deployments
 
 

--- a/docs/reference-architecture/csp.md
+++ b/docs/reference-architecture/csp.md
@@ -1,6 +1,24 @@
 ---
 title: "Multi-tenant Deployments"
 description: "Reference architecture for Cloud Service Providers deploying VergeOS as a multi-tenant IaaS platform with tenant isolation, resource allocation, and scalable infrastructure."
+semantic_keywords:
+  - "VergeOS CSP cloud service provider multi-tenant IaaS"
+  - "tenant isolation resource allocation scalable infrastructure"
+  - "service provider deployment architecture hosting platform"
+  - "multi-tenancy managed services VergeOS reference design"
+use_cases:
+  - csp_deployment_planning
+  - multi_tenant_architecture
+  - resource_allocation
+  - service_provider_infrastructure
+tags:
+  - reference-architecture
+  - csp
+  - multi-tenancy
+  - iaas
+  - tenants
+categories:
+  - Tenants
 ---
 
 # Multi-tenant Deployments

--- a/docs/reference-architecture/data-science.md
+++ b/docs/reference-architecture/data-science.md
@@ -1,3 +1,8 @@
+---
+title: "High-Performance Cluster Deployments"
+description: "Reference architecture for deploying VergeOS high-performance clusters for data science, machine learning, and analytics workloads with GPU acceleration and scalable storage."
+---
+
 # High-Performance Cluster Deployments
 
 

--- a/docs/reference-architecture/data-science.md
+++ b/docs/reference-architecture/data-science.md
@@ -1,6 +1,25 @@
 ---
 title: "High-Performance Cluster Deployments"
 description: "Reference architecture for deploying VergeOS high-performance clusters for data science, machine learning, and analytics workloads with GPU acceleration and scalable storage."
+semantic_keywords:
+  - "VergeOS high-performance cluster GPU data science machine learning"
+  - "HPC deployment analytics workloads scalable compute"
+  - "GPU acceleration model training inference cluster architecture"
+  - "data science infrastructure VergeOS reference design"
+use_cases:
+  - hpc_cluster_planning
+  - gpu_workload_deployment
+  - data_science_infrastructure
+  - ml_training_cluster
+tags:
+  - reference-architecture
+  - hpc
+  - gpu
+  - data-science
+  - machine-learning
+  - clustering
+categories:
+  - Private AI
 ---
 
 # High-Performance Cluster Deployments

--- a/docs/reference-architecture/edge.md
+++ b/docs/reference-architecture/edge.md
@@ -1,3 +1,8 @@
+---
+title: "Edge Cluster Deployments"
+description: "Reference architecture for deploying VergeOS edge clusters at branch offices and remote locations using low-power, small form factor hardware."
+---
+
 # Edge Cluster Deployments
 
 

--- a/docs/reference-architecture/edge.md
+++ b/docs/reference-architecture/edge.md
@@ -1,6 +1,24 @@
 ---
 title: "Edge Cluster Deployments"
 description: "Reference architecture for deploying VergeOS edge clusters at branch offices and remote locations using low-power, small form factor hardware."
+semantic_keywords:
+  - "VergeOS edge cluster branch office remote location deployment"
+  - "small form factor low-power hardware edge computing"
+  - "distributed infrastructure remote site management"
+  - "edge deployment reference architecture VergeOS"
+use_cases:
+  - edge_deployment_planning
+  - branch_office_infrastructure
+  - remote_site_management
+  - distributed_cluster_design
+tags:
+  - reference-architecture
+  - edge
+  - branch-office
+  - remote
+  - small-form-factor
+categories:
+  - System Administration
 ---
 
 # Edge Cluster Deployments

--- a/docs/reference-architecture/homelab.md
+++ b/docs/reference-architecture/homelab.md
@@ -1,3 +1,8 @@
+---
+title: "VergeOS Homelab Reference Architecture"
+description: "Reference architecture for deploying VergeOS in homelab environments, covering single-node, two-node cluster, and production-grade configurations with multi-tiered storage."
+---
+
 # VergeOS Homelab Reference Architecture
 
 ## Overview

--- a/docs/reference-architecture/homelab.md
+++ b/docs/reference-architecture/homelab.md
@@ -1,6 +1,24 @@
 ---
 title: "VergeOS Homelab Reference Architecture"
 description: "Reference architecture for deploying VergeOS in homelab environments, covering single-node, two-node cluster, and production-grade configurations with multi-tiered storage."
+semantic_keywords:
+  - "VergeOS homelab single-node two-node cluster setup"
+  - "home virtualization lab environment hardware recommendations"
+  - "multi-tiered storage NVMe SSD homelab configuration"
+  - "homelab reference architecture VergeOS deployment"
+use_cases:
+  - homelab_deployment_planning
+  - single_node_setup
+  - two_node_cluster_design
+  - homelab_storage_configuration
+tags:
+  - reference-architecture
+  - homelab
+  - single-node
+  - clustering
+  - storage-tiers
+categories:
+  - Getting Started
 ---
 
 # VergeOS Homelab Reference Architecture

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,3 +1,8 @@
+---
+title: "Support Options"
+description: "Contact VergeOS support via phone, email, or the customer portal for assistance with your VergeOS environment."
+---
+
 # Support Options
 
 We're here to help! Choose the option that works best for you to get in touch with our support team.

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,6 +1,21 @@
 ---
 title: "Support Options"
 description: "Contact VergeOS support via phone, email, or the customer portal for assistance with your VergeOS environment."
+semantic_keywords:
+  - "VergeOS support contact phone email ticket"
+  - "technical support hours availability emergency"
+  - "open support ticket help desk assistance"
+use_cases:
+  - contact_support
+  - open_support_ticket
+  - emergency_support
+tags:
+  - support
+  - contact
+  - help
+  - ticket
+categories:
+  - Support
 ---
 
 # Support Options

--- a/docs/verge-bot.md
+++ b/docs/verge-bot.md
@@ -1,4 +1,6 @@
 ---
+title: "VergeBot"
+description: "AI-powered chatbot assistant for VergeOS documentation and support questions."
 hide:
   - navigation
   - toc

--- a/docs/verge-bot.md
+++ b/docs/verge-bot.md
@@ -1,6 +1,20 @@
 ---
 title: "VergeBot"
 description: "AI-powered chatbot assistant for VergeOS documentation and support questions."
+semantic_keywords:
+  - "VergeOS chatbot AI assistant documentation help"
+  - "VergeBot support questions automated assistance"
+use_cases:
+  - get_quick_answers
+  - search_documentation
+  - troubleshooting_assistance
+tags:
+  - ai
+  - chatbot
+  - support
+  - search
+categories:
+  - Support
 hide:
   - navigation
   - toc


### PR DESCRIPTION
## Summary
- Adds a `Validate Frontmatter` CI job to the lint workflow enforcing `title` and `description` on all doc files, plus `slug`, `date`, `tags`, `categories` for KB articles
- Adds frontmatter to 6 files missed in #425 (glossary, reference architectures, verge-bot)
- Updates README.md and CLAUDE.md with the new frontmatter schema documentation

## Test plan
- [ ] Verify `Validate Frontmatter` check passes
- [ ] Verify existing `Validate Widget Links` and `Check Internal Links` checks still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)