### PR TITLE
📝 docs: add guidance on multi-node chassis servers

### DIFF
--- a/docs/implementation-guide/sizing.md
+++ b/docs/implementation-guide/sizing.md
@@ -40,7 +40,7 @@ categories:
 - 1 x 10GbE NIC for Core Fabric Network (Intel, NVIDIA Mellanox, or Broadcom)
 
 !!! warning "Multi-Node Chassis Servers"
-    We strongly advise against using multi-node chassis servers (twin servers, quad-node servers, etc.) for VergeOS deployments. These devices share power supplies, backplane, and management controllers across multiple nodes, creating a shared failure domain that undermines high availability. A single chassis-level failure can take out multiple nodes simultaneously. Use independent, standalone rack-mount servers instead. See [Why Multi-Node Chassis Servers Are Not Recommended](/knowledge-base/posts/why-multi-node-chassis-not-recommended/) for details.
+    We strongly advise against using multi-node chassis servers (twin servers, quad-node servers, etc.) for VergeOS deployments. These devices share power supplies, backplane, and management controllers across multiple nodes, creating a shared failure domain that undermines high availability. A single chassis-level failure can take out multiple nodes simultaneously. Use independent, standalone rack-mount servers instead. See [Why Multi-Node Chassis Servers Are Not Recommended](/knowledge-base/why-multi-node-chassis-not-recommended/) for details.
 
 ### Controller Nodes (Node 1 and Node 2)
 

--- a/docs/implementation-guide/sizing.md
+++ b/docs/implementation-guide/sizing.md
@@ -39,6 +39,9 @@ categories:
 - 1 x 1GbE NIC for External Network (Intel, NVIDIA Mellanox, or Broadcom)
 - 1 x 10GbE NIC for Core Fabric Network (Intel, NVIDIA Mellanox, or Broadcom)
 
+!!! warning "Multi-Node Chassis Servers"
+    We strongly advise against using multi-node chassis servers (twin servers, quad-node servers, etc.) for VergeOS deployments. These devices share power supplies, backplane, and management controllers across multiple nodes, creating a shared failure domain that undermines high availability. A single chassis-level failure can take out multiple nodes simultaneously. Use independent, standalone rack-mount servers instead. See [Why Multi-Node Chassis Servers Are Not Recommended](/knowledge-base/posts/why-multi-node-chassis-not-recommended/) for details.
+
 ### Controller Nodes (Node 1 and Node 2)
 
 - 1 x +2.7GHz CPU

--- a/docs/knowledge-base/posts/why-multi-node-chassis-not-recommended.md
+++ b/docs/knowledge-base/posts/why-multi-node-chassis-not-recommended.md
@@ -1,0 +1,101 @@
+---
+title: Why Multi-Node Chassis Servers Are Not Recommended for VergeOS
+slug: why-multi-node-chassis-not-recommended
+description: Explains why single chassis multi-server devices (twin servers, multi-node servers) are not recommended for VergeOS deployments due to shared failure domain risks.
+author: VergeOS Documentation Team
+published: true
+date: 2026-04-16
+tags: [hardware, best practices, high availability, vSAN, nodes]
+categories:
+  - Best Practices
+  - Infrastructure Planning
+editor: markdown
+dateCreated: 2026-04-16
+---
+
+# Why Multi-Node Chassis Servers Are Not Recommended for VergeOS
+
+## Overview
+
+!!! info "Key Takeaway"
+    We strongly advise against using multi-node chassis servers (twin servers, quad-node servers, etc.) for VergeOS deployments. These devices pack multiple independent server nodes into a single chassis, creating a **shared failure domain** that undermines the high availability VergeOS is designed to provide.
+
+VergeOS achieves redundancy by distributing workloads and data across **independent nodes**. When multiple nodes share a single chassis — along with its power supplies, backplane, and management controller — a single hardware event can take out multiple nodes at once. This directly defeats the purpose of node-level redundancy.
+
+## What Are Multi-Node Chassis Servers?
+
+Multi-node chassis servers are systems that pack two or more independent server nodes into a single physical enclosure. Common configurations include:
+
+- **Twin servers** — Two nodes in a single 1U or 2U chassis
+- **Quad-node servers** — Four nodes in a 2U chassis
+
+While these devices are marketed for density and cost savings, they come with a critical trade-off: **the nodes are not truly independent**. They typically share:
+
+- **Power supplies** — All nodes draw from the same PSU pool
+- **Backplane / midplane** — A shared circuit board interconnecting all nodes
+- **Chassis management controller** — A single management interface for all nodes
+- **Cooling** — Shared fans and airflow paths
+
+## The Shared Failure Domain Problem
+
+In a properly designed VergeOS cluster, each node is an independent failure domain. If one node goes down, the remaining nodes continue operating and the vSAN maintains data availability. This only works when node failures are **uncorrelated** — one node failing doesn't cause another to fail.
+
+Multi-node chassis servers break this assumption. When nodes share physical infrastructure, failures become correlated:
+
+- A chassis with two nodes fails → **two nodes go down simultaneously**
+- A chassis with four nodes fails → **four nodes go down simultaneously**
+
+In a small cluster, this can be catastrophic. For example, in a four-node VergeOS cluster using two twin-server chassis, a single chassis failure takes out **half the cluster** — potentially exceeding the fault tolerance of the vSAN and causing data unavailability.
+
+## Common Failure Scenarios
+
+### Power Contention and Instability
+
+All nodes in a multi-node chassis draw from a shared power supply pool. This creates several risks:
+
+- **Runaway power draw** — A malfunctioning node (stuck in a boot loop, experiencing a firmware bug, or under extreme load) can consume a disproportionate share of the power budget, starving other nodes of stable power.
+- **PSU throttling** — When total power draw exceeds the available budget, the chassis may throttle power delivery to all nodes, causing performance degradation or unexpected shutdowns across the board.
+- **PSU failure cascade** — In an N+1 redundancy configuration, losing one PSU while nodes are under heavy load can trigger cascading shutdowns of multiple nodes.
+
+### Network Disruption from Power Instability
+
+This is one of the most common — and most disruptive — failure patterns we see. When power instability causes a node to behave erratically, it can:
+
+- **Flood the shared backplane with malformed network traffic**, disrupting communication for all nodes in the chassis
+- **Cause intermittent network drops** that are extremely difficult to diagnose because individual nodes may test fine in isolation
+- **Disrupt both storage and VM traffic simultaneously**, since the backplane typically carries all inter-node communication
+
+In an HCI environment like VergeOS, where storage traffic and VM traffic share the network infrastructure, this kind of disruption can lead to split-brain scenarios, stalled I/O, and potential data integrity issues if writes were in flight.
+
+### Management Controller Failures
+
+Multi-node chassis typically use a shared chassis management controller (CMC) for out-of-band management. Known issues include:
+
+- **Firmware updates to the CMC can force-reboot all nodes** in the chassis, not just one
+- **CMC hangs** may require a full chassis power cycle, taking all nodes offline
+- **Shared management networks** where one node's management traffic can interfere with access to other nodes
+
+### Firmware Interdependencies
+
+Multi-node chassis often require chassis firmware, node BIOS, and management controller firmware to be updated in lockstep. This creates:
+
+- **Larger maintenance windows** — You can't update one node at a time; the entire chassis must be updated together
+- **Increased risk during updates** — A failed firmware update can affect all nodes in the chassis
+
+## What We Recommend Instead
+
+We recommend using **independent, standalone servers** — typically 1U or 2U single-node rack-mount servers — for VergeOS deployments. This ensures:
+
+- **Each node is a truly independent failure domain** — A hardware failure on one node has zero impact on other nodes
+- **Dedicated power supplies per node** — No power contention or shared PSU failures
+- **Independent network interfaces** — No shared backplane that can propagate network issues
+- **Independent management controllers** — Each node has its own BMC/IPMI for out-of-band management
+- **Flexible maintenance** — Firmware updates, hardware replacements, and power cycling can be performed on individual nodes without affecting the rest of the cluster
+
+!!! tip "Planning Your Deployment"
+    When sizing a VergeOS cluster, always plan for the loss of an individual node, not a chassis. Using independent servers makes this calculation straightforward — losing one server means losing one node's worth of compute and storage capacity.
+
+## Feedback
+
+!!! question "Need Help?"
+    If you have questions about hardware compatibility or need guidance on selecting hardware for your VergeOS deployment, please don't hesitate to reach out to the [VergeOS Support Team](https://support.verge.io).


### PR DESCRIPTION
## Summary
- Adds a new KB article explaining why multi-node chassis servers (twin servers, quad-node servers) are not recommended for VergeOS deployments, covering shared failure domains, power contention, backplane network disruption, and management controller risks
- Adds a cross-reference warning to the Sizing & Hardware Requirements guide linking to the new article

## Test plan
- [x] Verify KB article renders correctly on the local dev server
- [x] Verify the warning admonition appears in the sizing guide
- [x] Verify the cross-reference link resolves to the KB article

🤖 Generated with [Claude Code](https://claude.com/claude-code)