### PR TITLE
docs: PXE boot setup guide

### DIFF
--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -36,7 +36,7 @@ VergeOS has a built-in PXE boot service that lets you install and/or run nodes w
 | **First-time install via PXE** | Alternative to USB installer. Node PXE-boots to the installer, you select Scale-Out / Compute / Storage, installer completes and node joins the cluster |
 | **Every-boot PXE (diskless)** | Node has no local drives (or none configured as bootable). Every reboot pulls the running VergeOS image from the cluster over PXE. Common pattern for diskless compute blades |
 
-Both use the same underlying service: the provider cluster runs dnsmasq on a designated vNet, serves the iPXE loader over TFTP, and the full VergeOS image over HTTP.
+Both use the same underlying service: the provider cluster runs dnsmasq on a designated vNet and serves the VergeOS boot image over the network.
 
 ---
 
@@ -176,10 +176,9 @@ Use case: compute nodes with no local disks, or nodes that should always pull a 
 1. Node powers on → boot policy → LAN Boot
 2. NIC sends DHCP on the install VLAN
 3. Verge's dnsmasq responds with IP + `next-server` + boot filename
-4. Node TFTPs the iPXE loader from Verge
-5. iPXE pulls the full VergeOS image over HTTP
-6. VergeOS loads into RAM, node rejoins the cluster
-7. Reboot → repeat from step 1
+4. Node downloads the VergeOS boot image from Verge
+5. VergeOS loads into RAM, node rejoins the cluster
+6. Reboot → repeat from step 1
 
 No local storage, no per-node customization. Scale identically across N nodes with the same boot policy / service profile.
 
@@ -271,6 +270,5 @@ Work through this list first when PXE isn't behaving. Most failures trace back t
 
 ## Open questions / TODOs
 
-- [ ] iPXE config boot — 4.12.6 release notes mentioned support for "iPXE config boot"; figure out what this means and when/why you'd use it
 - [ ] Recommended minimum VergeOS version for PXE install of new nodes (any version caveats?)
-- [ ] Document the actual packets on the wire for someone troubleshooting (what DHCP options Verge sets, what the iPXE script looks like)
+- [ ] Document the actual packets on the wire for someone troubleshooting (what DHCP options Verge sets)

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -23,8 +23,6 @@ tags:
 **Audience:** System administrators and support engineers deploying VergeOS nodes without creating USB installers or having boot disks
 **Covers:** First-time PXE installs AND every-boot PXE for diskless compute nodes
 
-> TODO flags throughout mark places that need verification against real config or screenshots.
-
 ---
 
 ## 1. Overview
@@ -265,9 +263,3 @@ Work through this list first when PXE isn't behaving. Most failures trace back t
 - [Installation Guide](https://docs.verge.io/implementation-guide/installation-guide/)
 - [Scale-out Node Installation Guide](https://docs.verge.io/implementation-guide/scale-out-nodes/)
 - Docs issue for this guide: [verge-io/docs#435](https://github.com/verge-io/docs/issues/435)
-
----
-
-## Open questions / TODOs
-
-- [ ] Recommended minimum VergeOS version for PXE install of new nodes (any version caveats?)

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -20,7 +20,7 @@ tags:
 # PXE Boot Guide for VergeOS Nodes
 
 **Status:** DRAFT — working version
-**Audience:** System administrators and support engineers installing or running VergeOS nodes without USB media
+**Audience:** System administrators and support engineers running VergeOS nodes without USB media, or adding compute nodes that are diskless
 **Covers:** First-time PXE installs AND every-boot PXE for diskless compute nodes
 
 > TODO flags throughout mark places that need verification against real config or screenshots.

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -222,6 +222,25 @@ Any change to that chain can prevent PXE from working on the next reboot.
 
 ## 9. Troubleshooting
 
+### 9.1 Common things to verify
+
+Work through this list first when PXE isn't behaving. Most failures trace back to one of these:
+
+- **Did the node get a DHCP lease?** Watch the boot console — it should show "DHCP..." followed by an IP. If no IP, the DHCP phase itself is failing.
+- **Is the IP in the expected subnet?** If the node gets a lease but the IP isn't from the pool you configured on the Verge External vNet, a different DHCP server answered. A rogue/corporate DHCP on the same L2 will usually win the race.
+- **No competing DHCP server on the segment?** This is the #1 cause of silent PXE failures. Verge's dnsmasq must be the only DHCP on the VLAN. See §4.1.
+- **PXE option set to `ybos`** on the External vNet? Without this, Verge answers DHCP but doesn't hand out the PXE boot filename.
+- **DHCP enabled on the vNet** (not just configured)? The checkbox must be checked and the network powered on.
+- **Gateway field on the DHCP scope blank?** Handing out a gateway causes PXE clients to try routing TFTP/HTTP off-network. See §3.2.
+- **Native VLAN match?** The switch port (or vNIC) carrying the node's PXE NIC must have the Verge PXE VLAN as its native/access VLAN. PXE broadcasts are untagged. See §2 and §5.2.
+- **Correct NIC configured for PXE?** BIOS/UEFI boot order (or the boot policy on managed platforms) must point at the NIC actually cabled to the PXE network.
+- **Physical connectivity?** Link lights on both ends, cable seated, switch port not administratively down or error-disabled.
+- **External vNet status is `Running`?** If the vNet is stopped/initializing, dnsmasq isn't answering.
+- **VergeOS cluster is healthy?** A cluster that's degraded or with controllers down may not be serving PXE properly. Check the main dashboard.
+- **MAC registration (for nodes previously joined)?** If a NIC was swapped or a Service Profile rebuilt, the new MAC may not be recognized. See §8.
+
+### 9.2 Specific error codes
+
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
 | Node gets DHCP lease, no PXE menu | Competing DHCP on segment, OR PXE option not set to `ybos` | Verify only Verge DHCP is on the VLAN; verify the vNet's PXE option |
@@ -229,6 +248,8 @@ Any change to that chain can prevent PXE from working on the next reboot.
 | `PXE-E32: TFTP open timeout` | Firewall or VLAN isolation between node and Verge | Check L2 path from node to the Verge vNet |
 | Boot loops | BIOS/boot order issue — node booting from empty local disk | Fix boot order, or remove Local Disk from the boot policy |
 | Node hangs at "PXE-MOF: Exiting..." | Usually a boot order issue — PXE succeeded but machine tried to fall through to another boot device that isn't bootable | Set PXE as the only boot option, or ensure local disk is actually bootable post-install |
+| Node gets IP but from the wrong subnet | Rogue/competing DHCP server answered first | Isolate the PXE VLAN; disable other DHCP on the segment |
+| No DHCP lease at all | Native VLAN mismatch, cable issue, NIC not configured for PXE/LAN Boot | Verify switch port native VLAN matches Verge PXE VLAN; check physical link; enable PXE/network boot on the NIC |
 
 ---
 

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -109,7 +109,16 @@ Pick a VLAN that:
 
 ### 4.3 Redundant switch ports
 
-TODO: recommendations for bonded/redundant NICs on the install VLAN vs single-path.
+**Recommended pattern: a single dedicated PXE NIC/port per node** (on the maintenance network). PXE booting runs before the OS forms any bond or team, so PXE will always use a single physical NIC anyway — making it dedicated keeps the boot path simple and predictable.
+
+**If you must run PXE over an existing bonded pair of externals** (e.g. you don't have a spare NIC for a dedicated maintenance link):
+
+- Designate one of the two physical NICs in the bond as the **primary** PXE NIC
+- Configure the node's BIOS/UEFI (or boot policy) to boot from **that specific NIC only** — not the bond abstraction
+- Make sure that primary NIC is on a switch port carrying the PXE VLAN as native
+- After VergeOS boots, the OS forms the bond and uses both links for runtime traffic — PXE only cares about the one link it boots through
+
+You lose PXE redundancy this way (if the primary NIC's switch port is down, PXE won't succeed), but you keep full runtime network redundancy once the node is up. For every-boot diskless nodes this is the main tradeoff to be aware of.
 
 ---
 
@@ -268,4 +277,3 @@ Work through this list first when PXE isn't behaving. Most failures trace back t
 - [ ] Recommended minimum VergeOS version for PXE install of new nodes (any version caveats?)
 - [ ] Document the actual packets on the wire for someone troubleshooting (what DHCP options Verge sets, what the iPXE script looks like)
 - [ ] Add Dell iDRAC / HPE iLO / Supermicro BMC boot-order notes to §5.3
-- [ ] Redundant NIC recommendations for the install VLAN in §4.3

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -20,7 +20,7 @@ tags:
 # PXE Boot Guide for VergeOS Nodes
 
 **Status:** DRAFT — working version
-**Audience:** System administrators and support engineers running VergeOS nodes without USB media, or adding compute nodes that are diskless
+**Audience:** System administrators and support engineers deploying VergeOS nodes without creating USB installers or having boot disks
 **Covers:** First-time PXE installs AND every-boot PXE for diskless compute nodes
 
 > TODO flags throughout mark places that need verification against real config or screenshots.

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -44,6 +44,7 @@ Both use the same underlying service: the provider cluster runs dnsmasq on a des
 
 - An **operational VergeOS cluster** (at minimum, controller node up and reachable)
 - An **External network** in VergeOS that will carry the PXE install traffic
+- **Dedicated PXE NIC (recommended)** — the PXE network should be on a separate NIC on each node, dedicated to PXE booting. Typically implemented as a maintenance network, isolated from production data paths so that PXE traffic doesn't compete with other network roles on the same interface
 - **Switch configuration** allowing the target PXE NIC to reach the Verge PXE network
 - **Native VLAN match** — the native/access VLAN on the target node's switch port (or vNIC, if applicable) **must match the VLAN of the Verge PXE network**. PXE boot broadcasts leave the NIC untagged, so they land on whatever VLAN the port treats as native. If the native VLAN doesn't match where Verge is serving PXE, the boot request never reaches Verge's dnsmasq and the node will get no PXE response.
 - **BIOS/UEFI or boot policy** on the target node configured to boot from NIC/LAN

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -264,7 +264,6 @@ Work through this list first when PXE isn't behaving. Most failures trace back t
 
 ## Open questions / TODOs
 
-- [ ] Screenshots for each major step (PXE vNet form, boot policy config, the `Verge.io OS PXE` boot menu)
 - [ ] iPXE config boot — 4.12.6 release notes mentioned support for "iPXE config boot"; figure out what this means and when/why you'd use it
 - [ ] Recommended minimum VergeOS version for PXE install of new nodes (any version caveats?)
 - [ ] Document the actual packets on the wire for someone troubleshooting (what DHCP options Verge sets, what the iPXE script looks like)

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -217,11 +217,26 @@ Any change to that chain can prevent PXE from working on the next reboot.
 
 ### If the node fails to boot after a NIC change
 
+Start by verifying the basics:
+
 - Check console output for PXE error codes
 - Verify the new NIC/vNIC is on the correct VLAN (native VLAN on the vNIC, or access VLAN on the switch)
-- **Refresh the node's drives and NICs in VergeOS** — on the node's dashboard in the provider UI, run the **Refresh → Drives and NICs** action. PXE-booting nodes need this to pick up the new MAC after a hardware change; without it, the cluster still references the old MAC and the node won't be recognized
-- Check VergeOS infrastructure → Nodes for the new MAC; if it's still not registered after the refresh, the node may need to be re-added
 - If using a managed boot policy, verify it still references a valid vNIC
+
+If the hardware side looks correct but the cluster still references the old MAC, you have two ways to update VergeOS's view of the node:
+
+**Option 1 — Refresh Drives and NICs (node is running / bootable):**
+On the node's dashboard in the provider UI, run the **Refresh → Drives and NICs** action. The cluster re-detects the current hardware and picks up the new MAC automatically.
+
+**Option 2 — Manually edit the NIC's MAC (node is down, same NIC slot, new MAC):**
+Useful when the NIC hardware / slot hasn't changed but the MAC did — for example, a vNIC rebuild or service profile change on a managed platform. With the node offline:
+- Navigate to the node's dashboard → NICs
+- Edit the NIC entry corresponding to the PXE network
+- Update the stored MAC to match the new one
+- **Reboot the PXE network** (power-cycle the External vNet) so dnsmasq picks up the new MAC-to-config mapping
+- The node should boot correctly on the next attempt
+
+If neither option resolves it, the node may need to be removed from the cluster and re-added.
 
 ---
 

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -270,6 +270,7 @@ Work through this list first when PXE isn't behaving. Most failures trace back t
 | Node hangs at "PXE-MOF: Exiting..." | Usually a boot order issue — PXE succeeded but machine tried to fall through to another boot device that isn't bootable | Set PXE as the only boot option, or ensure local disk is actually bootable post-install |
 | Node gets IP but from the wrong subnet | Rogue/competing DHCP server answered first | Isolate the PXE VLAN; disable other DHCP on the segment |
 | No DHCP lease at all | Native VLAN mismatch, cable issue, NIC not configured for PXE/LAN Boot | Verify switch port native VLAN matches Verge PXE VLAN; check physical link; enable PXE/network boot on the NIC |
+| After a diskless install completes, the node only PXE-boots back into the installer (not the running OS) | PXE server's state hasn't refreshed post-install — it's still serving the install image for that node | Reboot the PXE network (power-cycle the External vNet) and apply rules. On next boot, the node should get the running OS image |
 
 ---
 

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -1,0 +1,254 @@
+---
+title: "PXE Boot Setup Guide"
+description: "Configure VergeOS to PXE boot nodes for installation or every-boot runtime — no USB installer required. Covers External vNet setup, VLAN/DHCP requirements, and UCS blade configuration."
+semantic_keywords:
+  - "VergeOS PXE boot setup"
+  - "diskless compute node PXE"
+  - "PXE install VergeOS nodes"
+  - "UCS blade PXE boot VergeOS"
+  - "ybos PXE option"
+use_cases:
+  - pxe_boot_node_installation
+  - diskless_compute_node_deployment
+  - mass_node_provisioning
+tags:
+  - installation
+  - pxe
+  - networking
+  - diskless
+  - ucs
+---
+
+# PXE Boot Guide for VergeOS Nodes
+
+**Status:** DRAFT — working version
+**Audience:** System administrators and support engineers installing or running VergeOS nodes without USB media
+**Covers:** First-time PXE installs AND every-boot PXE for diskless compute nodes
+**Source material:** Internal KB + field experience (MacStadium UCS deployment, Cody Robinson IZT deployment, Jeff's own lab work)
+
+> TODO flags throughout mark places that need verification against real config or screenshots.
+
+---
+
+## 1. Overview
+
+VergeOS has a built-in PXE boot service that lets you install and/or run nodes without creating USB installers. Two distinct scenarios:
+
+| Scenario | Use case |
+|----------|----------|
+| **First-time install via PXE** | Alternative to USB installer. Node PXE-boots to the installer, you select Scale-Out / Compute / Storage, installer completes and node joins the cluster |
+| **Every-boot PXE (diskless)** | Node has no local drives (or none configured as bootable). Every reboot pulls the running VergeOS image from the cluster over PXE. Standard pattern for UCS-based compute blades |
+
+Both use the same underlying service: the provider cluster runs dnsmasq on a designated vNet, serves the iPXE loader over TFTP, and the full VergeOS image over HTTP.
+
+---
+
+## 2. Prerequisites
+
+- An **operational VergeOS cluster** (at minimum, controller nodes up and reachable)
+- An **External network** in VergeOS that will carry the PXE install traffic
+- **Switch configuration** allowing the target PXE NIC to reach the Verge PXE network
+- **Native VLAN match** — the native/access VLAN on the target node's switch port (or UCS vNIC) **must match the VLAN of the Verge PXE network**. PXE boot broadcasts leave the NIC untagged, so they land on whatever VLAN the port treats as native. If the native VLAN doesn't match where Verge is serving PXE, the boot request never reaches Verge's dnsmasq and the node will get no PXE response.
+- **BIOS/UEFI or Service Profile** on the target node configured to boot from NIC/LAN
+- **No competing DHCP** on the PXE segment (see §4 below — this is the #1 cause of silent PXE failures)
+
+---
+
+## 3. Configure VergeOS to serve PXE
+
+The PXE service runs on a VergeOS **External vNet** with DHCP enabled and a specific PXE option set.
+
+### 3.1 Create or pick the External vNet
+
+1. **Networks → New External** (or edit an existing External vNet)
+2. Configure basic network settings:
+   - **Name** — something like `pxe-install` or `install-vlan-505`
+   - **Layer 2 Type** — `vLan` (typically)
+   - **Layer 2 ID** — your VLAN ID (e.g. `505`)
+   - **Interface Network** — the physical network backing this vNet (typically `External Bond 1`)
+   - **IP Address Type** — `Static`
+   - **IP Address** — the router IP for this network (clients will use this as gateway), e.g. `10.50.5.10`
+   - **Network Address** — CIDR, e.g. `10.50.5.0/24`
+
+### 3.2 Enable DHCP
+
+- Check the **DHCP** option
+- Set **DHCP Start Address** and **DHCP Stop Address** for the install pool
+- VergeOS's dnsmasq will be the authoritative DHCP for this segment
+- **Do NOT set a client Gateway** on this DHCP scope — leave the **Gateway** field blank. The PXE network should be a flat, self-contained install segment. Handing out a gateway causes PXE clients to try routing their TFTP/HTTP fetches off-network, and installs a default route that can conflict with the production networks the node will use after install
+
+### 3.3 Set the PXE option to `ybos`
+
+TODO: confirm exact UI location of the PXE option (is it on the External vNet form itself, or on an advanced settings tab?). The value must be the literal string `ybos` — this is what tells Verge to serve the VergeOS installer/runtime over PXE.
+
+### 3.4 Power on the vNet
+
+- **Submit** the form
+- On the resulting dashboard, click **Power On**
+- Verify the network status is `Running`
+
+---
+
+## 4. Network considerations (critical)
+
+### 4.1 No competing DHCP on the segment
+
+**This is the #1 cause of silent PXE failures.** If any other DHCP server is reachable on the VLAN where Verge is serving PXE (corporate DHCP, router DHCP, another hypervisor's DHCP), the two servers race. Whichever answers first wins. If the competing server wins, the node gets an IP but no `next-server` / `filename` PXE options — it boots but never finds the installer.
+
+Symptoms of a competing DHCP:
+- Node gets an IP lease but no PXE boot menu appears
+- `PXE-E53: No boot filename received`
+- Boot hangs at "Searching for boot server..."
+
+Recommended pattern: **dedicated install VLAN**, isolated at L2 from any other DHCP source.
+
+### 4.2 VLAN planning
+
+Pick a VLAN that:
+- Is trunked from your switch fabric to the physical nodes (or UCS Fabric Interconnects)
+- Has Verge as the only DHCP source
+- Is reachable from the Verge cluster's External network
+
+### 4.3 Redundant switch ports
+
+TODO: recommendations for bonded/redundant NICs on the install VLAN vs single-path.
+
+---
+
+## 5. Configure the node to PXE boot
+
+### 5.1 Generic BIOS/UEFI
+
+1. Enter BIOS/UEFI setup
+2. Set **Boot Order** so the PXE NIC is first (or only)
+3. Ensure **PXE / Network Boot** is enabled on the NIC
+4. Save and reboot
+
+### 5.2 Cisco UCS (blade servers)
+
+For UCS-managed blades, configuration lives in the **Service Profile** and **Boot Policy**, not in per-blade BIOS.
+
+**Boot Policy:**
+- Add **LAN Boot** entry
+- Set as primary (or only) boot entry
+- For diskless blades that need to PXE every boot: do NOT add a Local Disk entry, OR leave it lower priority with no bootable content
+
+**vNIC / VLAN for PXE** — two options:
+
+1. **Native VLAN on the vNIC** — Service Profile → vNICs → edit the boot vNIC → add VLAN 505 to allowed list, check `Native VLAN`. Untagged PXE broadcasts hit VLAN 505.
+2. **Boot VLAN on the LAN Boot entry** — set the VLAN explicitly in the Boot Policy's LAN Boot configuration. UCS tags the PXE boot request regardless of vNIC native VLAN.
+
+Use option 1 if the blade is dedicated to this network. Use option 2 if the blade will run production on a different native VLAN post-install.
+
+### 5.3 Other vendors
+
+TODO: Dell iDRAC / HPE iLO / Supermicro BMC notes.
+
+---
+
+## 6. First-time install via PXE
+
+(Alternative to USB installer)
+
+1. Target node boots → PXE menu appears showing `Verge.io OS PXE`
+2. Auto-boot countdown starts (default 1 second — press any key to interrupt)
+3. Installer loads
+4. Select install type:
+   - **Scale-Out** — node contributes both compute and vSAN storage
+   - **Compute** — compute only, no local storage in vSAN
+   - **Storage** — vSAN storage only
+5. Follow the installer prompts (cluster selection, NIC identification, disk selection, etc.) — same flow as USB installer
+6. Node reboots, joins cluster
+
+---
+
+## 7. Every-boot PXE (diskless nodes)
+
+Use case: compute blades with no local disks, or nodes that should always pull a fresh OS image from the cluster.
+
+### 7.1 Boot flow
+
+1. Blade powers on → Boot Policy → LAN Boot
+2. NIC sends DHCP on the install VLAN
+3. Verge's dnsmasq responds with IP + `next-server` + boot filename
+4. Blade TFTPs the iPXE loader from Verge
+5. iPXE pulls the full VergeOS image over HTTP
+6. VergeOS loads into RAM, node rejoins the cluster
+7. Reboot → repeat from step 1
+
+No local storage, no per-blade customization. Scale identically across N blades with the same Service Profile.
+
+### 7.2 Considerations
+
+- **PXE server must be up for the node to boot** — if the Verge cluster is down during a blade reboot, the blade hangs waiting for PXE response. Healthy cluster = never a problem, but worth noting for DR scenarios
+- **Boot Policy retry behavior** — check UCS "reboot on boot failure" settings to avoid stuck-in-loop scenarios
+- **All blades share the same image** — what the provider serves, all blades boot. Updates to the provider propagate to all blades at their next reboot
+
+---
+
+## 8. Changing a node's NIC configuration (caution)
+
+> ⚠️ **Changing the NIC or interface used by a PXE-booting node can break its ability to boot.** Proceed carefully, especially for every-boot PXE (diskless) nodes that depend on PXE for every startup.
+
+The PXE boot path is tied to a specific NIC and interface:
+- VergeOS identifies and registers nodes by MAC address
+- UCS Boot Policies reference a specific vNIC by name
+- BIOS/UEFI boot order points at a specific physical NIC
+- The switch port (or UCS vNIC) carries a specific native VLAN matching the PXE network
+
+Any change to that chain can prevent PXE from working on the next reboot.
+
+### What to watch out for
+
+- **Replacing the physical NIC** — new hardware = new MAC. VergeOS may not recognize the node, and any MAC-based DHCP reservations will no longer match
+- **Swapping which vNIC is used for LAN Boot** (UCS) — the new vNIC needs the correct native VLAN (or Boot VLAN set in the Boot Policy) to reach the Verge PXE network
+- **Rebuilding a UCS Service Profile** — unless MACs are preserved (via a MAC pool or explicit assignment), the blade will get a new MAC and Verge will see it as a new node
+- **Moving the cable to a different switch port** — the new port must carry the same native VLAN as the PXE network
+- **Changing bond configuration or NIC teaming** — PXE boots before the OS forms the bond, so it uses a single physical NIC; make sure that NIC is still on the PXE VLAN
+
+### Before making the change
+
+1. Note the current MAC address and which NIC/vNIC is used for boot
+2. If possible, have console/IPMI access during the first reboot after the change — in case PXE fails and you need to intervene
+3. If the node is part of a running cluster, consider putting it in maintenance / draining VMs first so you can take your time troubleshooting if needed
+4. For every-boot PXE nodes: verify after the change that the node successfully PXE-boots once before declaring the change complete
+
+### If the node fails to boot after a NIC change
+
+- Check console output for PXE error codes
+- Verify the new NIC/vNIC is on the correct VLAN (`Native VLAN` in UCS, or access VLAN on the switch)
+- Check VergeOS infrastructure → Nodes for the new MAC; if it's not registered, the node may need to be re-added
+- In UCS, verify the Boot Policy still references a valid vNIC
+
+---
+
+## 9. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Node gets DHCP lease, no PXE menu | Competing DHCP on segment, OR PXE option not set to `ybos` | Verify only Verge DHCP is on the VLAN; verify the vNet's PXE option |
+| `PXE-E53: No boot filename received` | PXE option missing or DHCP not enabled on the vNet | Enable DHCP; set PXE option to `ybos` |
+| `PXE-E32: TFTP open timeout` | Firewall or VLAN isolation between node and Verge | Check L2 path from node to the Verge vNet |
+| Boot loops | BIOS/boot order issue — node booting from empty local disk | Fix boot order, or remove Local Disk from UCS Boot Policy |
+| Node hangs at "PXE-MOF: Exiting..." | Usually a boot order issue — PXE succeeded but machine tried to fall through to another boot device that isn't bootable | Set PXE as the only boot option, or ensure local disk is actually bootable post-install |
+
+---
+
+## 10. Related
+
+- [Connect VergeOS to an Existing LAN/WAN](https://docs.verge.io/product-guide/networks/connect-lan-wan/)
+- [Installation Guide](https://docs.verge.io/implementation-guide/installation-guide/)
+- [Scale-out Node Installation Guide](https://docs.verge.io/implementation-guide/scale-out-nodes/)
+- Docs issue for this guide: [verge-io/docs#435](https://github.com/verge-io/docs/issues/435)
+
+---
+
+## Open questions / TODOs
+
+- [ ] Verify exact UI location and label for the PXE option (is it literally "PXE" dropdown with `ybos` as a choice? Text field? Advanced setting?)
+- [ ] Screenshots for each major step (PXE vNet form, Boot Policy config, the `Verge.io OS PXE` boot menu)
+- [ ] iPXE config boot — 4.12.6 release notes mentioned support for "iPXE config boot"; figure out what this means and when/why you'd use it
+- [ ] Recommended minimum VergeOS version for PXE install of new nodes (any version caveats?)
+- [ ] Document the actual packets on the wire for someone troubleshooting (what DHCP options Verge sets, what the iPXE script looks like)
+- [ ] Add Dell iDRAC / HPE iLO / Supermicro BMC boot-order notes to §5.3
+- [ ] Redundant NIC recommendations for the install VLAN in §4.3

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -73,7 +73,7 @@ The PXE service runs on a VergeOS **External vNet** with DHCP enabled and a spec
 - Check the **DHCP** option
 - Set **DHCP Start Address** and **DHCP Stop Address** for the install pool
 - VergeOS's dnsmasq will be the authoritative DHCP for this segment
-- **Do NOT set a client Gateway** on this DHCP scope — leave the **Gateway** field blank. The PXE network should be a flat, self-contained install segment. Handing out a gateway causes PXE clients to try routing their TFTP/HTTP fetches off-network, and installs a default route that can conflict with the production networks the node will use after install
+- **Gateway setting** — leave the DHCP **Gateway** field blank (VergeOS defaults it to the vNet's own router IP, which is fine), or explicitly set it to the vNet's router IP. Do NOT set it to an upstream/off-segment gateway — that makes PXE clients try to route their TFTP/HTTP fetches off-network, and installs a default route that can conflict with the production networks the node will use after install
 
 ### 3.3 Set the PXE option to `ybos`
 

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -75,9 +75,9 @@ The PXE service runs on a VergeOS **External vNet** with DHCP enabled and a spec
 - VergeOS's dnsmasq will be the authoritative DHCP for this segment
 - **Gateway setting** — leave the DHCP **Gateway** field blank (VergeOS defaults it to the vNet's own router IP, which is fine), or explicitly set it to the vNet's router IP. Do NOT set it to an upstream/off-segment gateway — that makes PXE clients try to route their TFTP/HTTP fetches off-network, and installs a default route that can conflict with the production networks the node will use after install
 
-### 3.3 Set the PXE option to `ybos`
+### 3.3 Set the PXE Boot option to `ybos`
 
-TODO: confirm exact UI location of the PXE option (is it on the External vNet form itself, or on an advanced settings tab?). The value must be the literal string `ybos` — this is what tells Verge to serve the VergeOS installer/runtime over PXE.
+On the External vNet form, locate the **PXE Boot** dropdown and select `ybos`. This tells Verge to serve the VergeOS installer/runtime over PXE on this network.
 
 ### 3.4 Power on the vNet
 
@@ -264,7 +264,6 @@ Work through this list first when PXE isn't behaving. Most failures trace back t
 
 ## Open questions / TODOs
 
-- [ ] Verify exact UI location and label for the PXE option (is it literally "PXE" dropdown with `ybos` as a choice? Text field? Advanced setting?)
 - [ ] Screenshots for each major step (PXE vNet form, boot policy config, the `Verge.io OS PXE` boot menu)
 - [ ] iPXE config boot — 4.12.6 release notes mentioned support for "iPXE config boot"; figure out what this means and when/why you'd use it
 - [ ] Recommended minimum VergeOS version for PXE install of new nodes (any version caveats?)

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -1,11 +1,10 @@
 ---
 title: "PXE Boot Setup Guide"
-description: "Configure VergeOS to PXE boot nodes for installation or every-boot runtime — no USB installer required. Covers External vNet setup, VLAN/DHCP requirements, and UCS blade configuration."
+description: "Configure VergeOS to PXE boot nodes for installation or every-boot runtime — no USB installer required. Covers External vNet setup, VLAN/DHCP requirements, and boot configuration for virtualized-NIC platforms."
 semantic_keywords:
   - "VergeOS PXE boot setup"
   - "diskless compute node PXE"
   - "PXE install VergeOS nodes"
-  - "UCS blade PXE boot VergeOS"
   - "ybos PXE option"
 use_cases:
   - pxe_boot_node_installation
@@ -16,7 +15,6 @@ tags:
   - pxe
   - networking
   - diskless
-  - ucs
 ---
 
 # PXE Boot Guide for VergeOS Nodes
@@ -24,7 +22,6 @@ tags:
 **Status:** DRAFT — working version
 **Audience:** System administrators and support engineers installing or running VergeOS nodes without USB media
 **Covers:** First-time PXE installs AND every-boot PXE for diskless compute nodes
-**Source material:** Internal KB + field experience (MacStadium UCS deployment, Cody Robinson IZT deployment, Jeff's own lab work)
 
 > TODO flags throughout mark places that need verification against real config or screenshots.
 
@@ -37,7 +34,7 @@ VergeOS has a built-in PXE boot service that lets you install and/or run nodes w
 | Scenario | Use case |
 |----------|----------|
 | **First-time install via PXE** | Alternative to USB installer. Node PXE-boots to the installer, you select Scale-Out / Compute / Storage, installer completes and node joins the cluster |
-| **Every-boot PXE (diskless)** | Node has no local drives (or none configured as bootable). Every reboot pulls the running VergeOS image from the cluster over PXE. Standard pattern for UCS-based compute blades |
+| **Every-boot PXE (diskless)** | Node has no local drives (or none configured as bootable). Every reboot pulls the running VergeOS image from the cluster over PXE. Common pattern for diskless compute blades |
 
 Both use the same underlying service: the provider cluster runs dnsmasq on a designated vNet, serves the iPXE loader over TFTP, and the full VergeOS image over HTTP.
 
@@ -48,8 +45,8 @@ Both use the same underlying service: the provider cluster runs dnsmasq on a des
 - An **operational VergeOS cluster** (at minimum, controller nodes up and reachable)
 - An **External network** in VergeOS that will carry the PXE install traffic
 - **Switch configuration** allowing the target PXE NIC to reach the Verge PXE network
-- **Native VLAN match** — the native/access VLAN on the target node's switch port (or UCS vNIC) **must match the VLAN of the Verge PXE network**. PXE boot broadcasts leave the NIC untagged, so they land on whatever VLAN the port treats as native. If the native VLAN doesn't match where Verge is serving PXE, the boot request never reaches Verge's dnsmasq and the node will get no PXE response.
-- **BIOS/UEFI or Service Profile** on the target node configured to boot from NIC/LAN
+- **Native VLAN match** — the native/access VLAN on the target node's switch port (or vNIC, if applicable) **must match the VLAN of the Verge PXE network**. PXE boot broadcasts leave the NIC untagged, so they land on whatever VLAN the port treats as native. If the native VLAN doesn't match where Verge is serving PXE, the boot request never reaches Verge's dnsmasq and the node will get no PXE response.
+- **BIOS/UEFI or boot policy** on the target node configured to boot from NIC/LAN
 - **No competing DHCP** on the PXE segment (see §4 below — this is the #1 cause of silent PXE failures)
 
 ---
@@ -105,7 +102,7 @@ Recommended pattern: **dedicated install VLAN**, isolated at L2 from any other D
 ### 4.2 VLAN planning
 
 Pick a VLAN that:
-- Is trunked from your switch fabric to the physical nodes (or UCS Fabric Interconnects)
+- Is trunked from your switch fabric to the physical nodes (or upstream fabric interconnects / blade chassis if applicable)
 - Has Verge as the only DHCP source
 - Is reachable from the Verge cluster's External network
 
@@ -124,21 +121,21 @@ TODO: recommendations for bonded/redundant NICs on the install VLAN vs single-pa
 3. Ensure **PXE / Network Boot** is enabled on the NIC
 4. Save and reboot
 
-### 5.2 Cisco UCS (blade servers)
+### 5.2 Managed / virtualized NIC platforms (if applicable)
 
-For UCS-managed blades, configuration lives in the **Service Profile** and **Boot Policy**, not in per-blade BIOS.
+Some hardware platforms (blade chassis, converged infrastructure, virtualized environments) present NICs as **vNICs** configured through a management layer rather than per-blade BIOS. In these cases, the configuration lives in a service profile and boot policy, not in per-node BIOS.
 
-**Boot Policy:**
-- Add **LAN Boot** entry
-- Set as primary (or only) boot entry
-- For diskless blades that need to PXE every boot: do NOT add a Local Disk entry, OR leave it lower priority with no bootable content
+**Boot policy:**
+- Add a **LAN Boot** entry
+- Set it as the primary (or only) boot entry
+- For diskless nodes that need to PXE every boot: do NOT add a Local Disk entry, OR leave it lower priority with no bootable content
 
 **vNIC / VLAN for PXE** — two options:
 
-1. **Native VLAN on the vNIC** — Service Profile → vNICs → edit the boot vNIC → add VLAN 505 to allowed list, check `Native VLAN`. Untagged PXE broadcasts hit VLAN 505.
-2. **Boot VLAN on the LAN Boot entry** — set the VLAN explicitly in the Boot Policy's LAN Boot configuration. UCS tags the PXE boot request regardless of vNIC native VLAN.
+1. **Native VLAN on the vNIC** — edit the boot vNIC in its service profile, add VLAN 505 to the allowed list, and mark 505 as the native VLAN. Untagged PXE broadcasts hit VLAN 505.
+2. **Boot VLAN on the LAN Boot entry** — set the VLAN explicitly in the boot policy's LAN Boot configuration. The platform tags the PXE boot request regardless of the vNIC's native VLAN.
 
-Use option 1 if the blade is dedicated to this network. Use option 2 if the blade will run production on a different native VLAN post-install.
+Use option 1 if the node is dedicated to this network. Use option 2 if the node will run production on a different native VLAN post-install.
 
 ### 5.3 Other vendors
 
@@ -164,25 +161,25 @@ TODO: Dell iDRAC / HPE iLO / Supermicro BMC notes.
 
 ## 7. Every-boot PXE (diskless nodes)
 
-Use case: compute blades with no local disks, or nodes that should always pull a fresh OS image from the cluster.
+Use case: compute nodes with no local disks, or nodes that should always pull a fresh OS image from the cluster.
 
 ### 7.1 Boot flow
 
-1. Blade powers on → Boot Policy → LAN Boot
+1. Node powers on → boot policy → LAN Boot
 2. NIC sends DHCP on the install VLAN
 3. Verge's dnsmasq responds with IP + `next-server` + boot filename
-4. Blade TFTPs the iPXE loader from Verge
+4. Node TFTPs the iPXE loader from Verge
 5. iPXE pulls the full VergeOS image over HTTP
 6. VergeOS loads into RAM, node rejoins the cluster
 7. Reboot → repeat from step 1
 
-No local storage, no per-blade customization. Scale identically across N blades with the same Service Profile.
+No local storage, no per-node customization. Scale identically across N nodes with the same boot policy / service profile.
 
 ### 7.2 Considerations
 
-- **PXE server must be up for the node to boot** — if the Verge cluster is down during a blade reboot, the blade hangs waiting for PXE response. Healthy cluster = never a problem, but worth noting for DR scenarios
-- **Boot Policy retry behavior** — check UCS "reboot on boot failure" settings to avoid stuck-in-loop scenarios
-- **All blades share the same image** — what the provider serves, all blades boot. Updates to the provider propagate to all blades at their next reboot
+- **PXE server must be up for the node to boot** — if the Verge cluster is down during a node reboot, the node hangs waiting for PXE response. Healthy cluster = never a problem, but worth noting for DR scenarios
+- **Boot policy retry behavior** — check the platform's "reboot on boot failure" settings to avoid stuck-in-loop scenarios
+- **All nodes share the same image** — what the provider serves, all nodes boot. Updates to the provider propagate to all nodes at their next reboot
 
 ---
 
@@ -192,17 +189,17 @@ No local storage, no per-blade customization. Scale identically across N blades 
 
 The PXE boot path is tied to a specific NIC and interface:
 - VergeOS identifies and registers nodes by MAC address
-- UCS Boot Policies reference a specific vNIC by name
+- Managed boot policies (where applicable) reference a specific vNIC by name
 - BIOS/UEFI boot order points at a specific physical NIC
-- The switch port (or UCS vNIC) carries a specific native VLAN matching the PXE network
+- The switch port (or vNIC, where applicable) carries a specific native VLAN matching the PXE network
 
 Any change to that chain can prevent PXE from working on the next reboot.
 
 ### What to watch out for
 
 - **Replacing the physical NIC** — new hardware = new MAC. VergeOS may not recognize the node, and any MAC-based DHCP reservations will no longer match
-- **Swapping which vNIC is used for LAN Boot** (UCS) — the new vNIC needs the correct native VLAN (or Boot VLAN set in the Boot Policy) to reach the Verge PXE network
-- **Rebuilding a UCS Service Profile** — unless MACs are preserved (via a MAC pool or explicit assignment), the blade will get a new MAC and Verge will see it as a new node
+- **Swapping which vNIC is used for LAN Boot** — the new vNIC needs the correct native VLAN (or Boot VLAN set in the boot policy) to reach the Verge PXE network
+- **Rebuilding a managed service profile** — unless MACs are preserved (via a MAC pool or explicit assignment), the node will get a new MAC and Verge will see it as a new node
 - **Moving the cable to a different switch port** — the new port must carry the same native VLAN as the PXE network
 - **Changing bond configuration or NIC teaming** — PXE boots before the OS forms the bond, so it uses a single physical NIC; make sure that NIC is still on the PXE VLAN
 
@@ -216,9 +213,9 @@ Any change to that chain can prevent PXE from working on the next reboot.
 ### If the node fails to boot after a NIC change
 
 - Check console output for PXE error codes
-- Verify the new NIC/vNIC is on the correct VLAN (`Native VLAN` in UCS, or access VLAN on the switch)
+- Verify the new NIC/vNIC is on the correct VLAN (native VLAN on the vNIC, or access VLAN on the switch)
 - Check VergeOS infrastructure → Nodes for the new MAC; if it's not registered, the node may need to be re-added
-- In UCS, verify the Boot Policy still references a valid vNIC
+- If using a managed boot policy, verify it still references a valid vNIC
 
 ---
 
@@ -229,7 +226,7 @@ Any change to that chain can prevent PXE from working on the next reboot.
 | Node gets DHCP lease, no PXE menu | Competing DHCP on segment, OR PXE option not set to `ybos` | Verify only Verge DHCP is on the VLAN; verify the vNet's PXE option |
 | `PXE-E53: No boot filename received` | PXE option missing or DHCP not enabled on the vNet | Enable DHCP; set PXE option to `ybos` |
 | `PXE-E32: TFTP open timeout` | Firewall or VLAN isolation between node and Verge | Check L2 path from node to the Verge vNet |
-| Boot loops | BIOS/boot order issue — node booting from empty local disk | Fix boot order, or remove Local Disk from UCS Boot Policy |
+| Boot loops | BIOS/boot order issue — node booting from empty local disk | Fix boot order, or remove Local Disk from the boot policy |
 | Node hangs at "PXE-MOF: Exiting..." | Usually a boot order issue — PXE succeeded but machine tried to fall through to another boot device that isn't bootable | Set PXE as the only boot option, or ensure local disk is actually bootable post-install |
 
 ---
@@ -246,7 +243,7 @@ Any change to that chain can prevent PXE from working on the next reboot.
 ## Open questions / TODOs
 
 - [ ] Verify exact UI location and label for the PXE option (is it literally "PXE" dropdown with `ybos` as a choice? Text field? Advanced setting?)
-- [ ] Screenshots for each major step (PXE vNet form, Boot Policy config, the `Verge.io OS PXE` boot menu)
+- [ ] Screenshots for each major step (PXE vNet form, boot policy config, the `Verge.io OS PXE` boot menu)
 - [ ] iPXE config boot — 4.12.6 release notes mentioned support for "iPXE config boot"; figure out what this means and when/why you'd use it
 - [ ] Recommended minimum VergeOS version for PXE install of new nodes (any version caveats?)
 - [ ] Document the actual packets on the wire for someone troubleshooting (what DHCP options Verge sets, what the iPXE script looks like)

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -193,7 +193,7 @@ No local storage, no per-node customization. Scale identically across N nodes wi
 > ⚠️ **Changing the NIC or interface used by a PXE-booting node can break its ability to boot.** Proceed carefully, especially for every-boot PXE (diskless) nodes that depend on PXE for every startup.
 
 The PXE boot path is tied to a specific NIC and interface:
-- VergeOS identifies and registers nodes by MAC address
+- **Node identity is tied to the MAC address of the NIC used during install** — this MAC must remain constant for the life of the node. If it changes, the cluster sees the node as new/unknown and it will not rejoin automatically
 - Managed boot policies (where applicable) reference a specific vNIC by name
 - BIOS/UEFI boot order points at a specific physical NIC
 - The switch port (or vNIC, where applicable) carries a specific native VLAN matching the PXE network

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -271,4 +271,3 @@ Work through this list first when PXE isn't behaving. Most failures trace back t
 ## Open questions / TODOs
 
 - [ ] Recommended minimum VergeOS version for PXE install of new nodes (any version caveats?)
-- [ ] Document the actual packets on the wire for someone troubleshooting (what DHCP options Verge sets)

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -236,7 +236,7 @@ Useful when the NIC hardware / slot hasn't changed but the MAC did — for examp
 - **Reboot the PXE network** (power-cycle the External vNet) so dnsmasq picks up the new MAC-to-config mapping
 - The node should boot correctly on the next attempt
 
-If neither option resolves it, the node may need to be removed from the cluster and re-added.
+If neither option resolves it, contact support.
 
 ---
 

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -42,7 +42,7 @@ Both use the same underlying service: the provider cluster runs dnsmasq on a des
 
 ## 2. Prerequisites
 
-- An **operational VergeOS cluster** (at minimum, controller nodes up and reachable)
+- An **operational VergeOS cluster** (at minimum, controller node up and reachable)
 - An **External network** in VergeOS that will carry the PXE install traffic
 - **Switch configuration** allowing the target PXE NIC to reach the Verge PXE network
 - **Native VLAN match** — the native/access VLAN on the target node's switch port (or vNIC, if applicable) **must match the VLAN of the Verge PXE network**. PXE boot broadcasts leave the NIC untagged, so they land on whatever VLAN the port treats as native. If the native VLAN doesn't match where Verge is serving PXE, the boot request never reaches Verge's dnsmasq and the node will get no PXE response.

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -219,7 +219,8 @@ Any change to that chain can prevent PXE from working on the next reboot.
 
 - Check console output for PXE error codes
 - Verify the new NIC/vNIC is on the correct VLAN (native VLAN on the vNIC, or access VLAN on the switch)
-- Check VergeOS infrastructure → Nodes for the new MAC; if it's not registered, the node may need to be re-added
+- **Refresh the node's drives and NICs in VergeOS** — on the node's dashboard in the provider UI, run the **Refresh → Drives and NICs** action. PXE-booting nodes need this to pick up the new MAC after a hardware change; without it, the cluster still references the old MAC and the node won't be recognized
+- Check VergeOS infrastructure → Nodes for the new MAC; if it's still not registered after the refresh, the node may need to be re-added
 - If using a managed boot policy, verify it still references a valid vNIC
 
 ---

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -19,7 +19,6 @@ tags:
 
 # PXE Boot Guide for VergeOS Nodes
 
-**Status:** DRAFT — working version
 **Audience:** System administrators and support engineers deploying VergeOS nodes without creating USB installers or having boot disks
 **Covers:** First-time PXE installs AND every-boot PXE for diskless compute nodes
 
@@ -251,8 +250,8 @@ Work through this list first when PXE isn't behaving. Most failures trace back t
 - **No competing DHCP server on the segment?** This is the #1 cause of silent PXE failures. Verge's dnsmasq must be the only DHCP on the VLAN. See §4.1.
 - **PXE option set to `ybos`** on the External vNet? Without this, Verge answers DHCP but doesn't hand out the PXE boot filename.
 - **DHCP enabled on the vNet** (not just configured)? The checkbox must be checked and the network powered on.
-- **Gateway field on the DHCP scope blank?** Handing out a gateway causes PXE clients to try routing TFTP/HTTP off-network. See §3.2.
-- **Native VLAN match?** The switch port (or vNIC) carrying the node's PXE NIC must have the Verge PXE VLAN as its native/access VLAN. PXE broadcasts are untagged. See §2 and §5.2.
+- **Gateway on the DHCP scope is sensible?** Blank or the vNet's own router IP is fine; an upstream/off-segment gateway will make PXE clients try to route off-network. See §3.2.
+- **Native VLAN match?** The switch port (or vNIC) carrying the node's PXE NIC must have the Verge PXE VLAN as its native/access VLAN. PXE broadcasts are untagged. See §2 and §5.1.
 - **Correct NIC configured for PXE?** BIOS/UEFI boot order (or the boot policy on managed platforms) must point at the NIC actually cabled to the PXE network.
 - **Physical connectivity?** Link lights on both ends, cable seated, switch port not administratively down or error-disabled.
 - **External vNet status is `Running`?** If the vNet is stopped/initializing, dnsmasq isn't answering.

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -184,7 +184,7 @@ No local storage, no per-node customization. Scale identically across N nodes wi
 
 - **PXE server must be up for the node to boot** — if the Verge cluster is down during a node reboot, the node hangs waiting for PXE response. Healthy cluster = never a problem, but worth noting for DR scenarios
 - **Boot policy retry behavior** — check the platform's "reboot on boot failure" settings to avoid stuck-in-loop scenarios
-- **All nodes share the same image** — what the provider serves, all nodes boot. Updates to the provider propagate to all nodes at their next reboot
+- **No per-node image management** — when the cluster is updated on the provider side, nodes pick up the new VergeOS version at their next reboot. You don't maintain separate OS images per node
 
 ---
 

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -258,6 +258,7 @@ Work through this list first when PXE isn't behaving. Most failures trace back t
 - **External vNet status is `Running`?** If the vNet is stopped/initializing, dnsmasq isn't answering.
 - **VergeOS cluster is healthy?** A cluster that's degraded or with controllers down may not be serving PXE properly. Check the main dashboard.
 - **MAC registration (for nodes previously joined)?** If a NIC was swapped or a Service Profile rebuilt, the new MAC may not be recognized. See §8.
+- **Try forcing the correct NIC via the BIOS boot manager.** If the persistent boot order isn't picking the right NIC, use the server's one-time boot manager (typically F11/F12 at POST, or a one-time boot override in the BMC / management controller) to explicitly select the PXE NIC. This isolates whether the issue is boot-order selection vs. something downstream like DHCP or PXE serving.
 
 ### 9.2 Specific error codes
 

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -124,32 +124,30 @@ You lose PXE redundancy this way (if the primary NIC's switch port is down, PXE 
 
 ## 5. Configure the node to PXE boot
 
-### 5.1 Generic BIOS/UEFI
+The node must be configured to boot from the NIC cabled into the PXE network. **Specific steps are vendor-specific and out of scope for this guide** — consult your server / BIOS / management controller documentation.
 
-1. Enter BIOS/UEFI setup
-2. Set **Boot Order** so the PXE NIC is first (or only)
-3. Ensure **PXE / Network Boot** is enabled on the NIC
-4. Save and reboot
+At minimum, ensure the following is true before reboot:
 
-### 5.2 Managed / virtualized NIC platforms (if applicable)
+- **PXE / network boot is enabled** on the target NIC
+- **The PXE NIC is first in the boot order**
+- For diskless / every-boot PXE scenarios: **no other bootable device takes priority** (e.g. a local disk with stale content)
 
-Some hardware platforms (blade chassis, converged infrastructure, virtualized environments) present NICs as **vNICs** configured through a management layer rather than per-blade BIOS. In these cases, the configuration lives in a service profile and boot policy, not in per-node BIOS.
+### 5.1 Managed / virtualized NIC platforms (if applicable)
+
+Some hardware platforms (blade chassis, converged infrastructure, virtualized environments) present NICs as **vNICs** configured through a management layer rather than per-node BIOS. In these cases, the PXE configuration lives in a service profile and boot policy, not in per-node BIOS.
+
+The PXE-relevant settings to configure (exact UI / menu paths are vendor-specific):
 
 **Boot policy:**
-- Add a **LAN Boot** entry
-- Set it as the primary (or only) boot entry
-- For diskless nodes that need to PXE every boot: do NOT add a Local Disk entry, OR leave it lower priority with no bootable content
+- Add a **LAN Boot** entry as the primary (or only) boot entry
+- For diskless every-boot PXE: do not include a Local Disk entry, or leave it lower priority with no bootable content
 
 **vNIC / VLAN for PXE** — two options:
 
-1. **Native VLAN on the vNIC** — edit the boot vNIC in its service profile, add VLAN 505 to the allowed list, and mark 505 as the native VLAN. Untagged PXE broadcasts hit VLAN 505.
+1. **Native VLAN on the vNIC** — add the PXE VLAN to the vNIC's allowed list and mark it as the vNIC's native VLAN. Untagged PXE broadcasts land on the PXE VLAN.
 2. **Boot VLAN on the LAN Boot entry** — set the VLAN explicitly in the boot policy's LAN Boot configuration. The platform tags the PXE boot request regardless of the vNIC's native VLAN.
 
 Use option 1 if the node is dedicated to this network. Use option 2 if the node will run production on a different native VLAN post-install.
-
-### 5.3 Other vendors
-
-TODO: Dell iDRAC / HPE iLO / Supermicro BMC notes.
 
 ---
 
@@ -276,4 +274,3 @@ Work through this list first when PXE isn't behaving. Most failures trace back t
 - [ ] iPXE config boot — 4.12.6 release notes mentioned support for "iPXE config boot"; figure out what this means and when/why you'd use it
 - [ ] Recommended minimum VergeOS version for PXE install of new nodes (any version caveats?)
 - [ ] Document the actual packets on the wire for someone troubleshooting (what DHCP options Verge sets, what the iPXE script looks like)
-- [ ] Add Dell iDRAC / HPE iLO / Supermicro BMC boot-order notes to §5.3

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -17,7 +17,7 @@ tags:
   - diskless
 ---
 
-# PXE Boot Guide for VergeOS Nodes
+# PXE Boot Setup Guide
 
 **Audience:** System administrators and support engineers deploying VergeOS nodes without creating USB installers or having boot disks
 **Covers:** First-time PXE installs AND every-boot PXE for diskless compute nodes
@@ -31,7 +31,7 @@ VergeOS has a built-in PXE boot service that lets you install and/or run nodes w
 | Scenario | Use case |
 |----------|----------|
 | **First-time install via PXE** | Alternative to USB installer. Node PXE-boots to the installer, you select Scale-Out / Compute / Storage, installer completes and node joins the cluster |
-| **Every-boot PXE (diskless)** | Node has no local drives (or none configured as bootable). Every reboot pulls the running VergeOS image from the cluster over PXE. Common pattern for diskless compute blades |
+| **Every-boot PXE (diskless)** | Node has no local drives (or none configured as bootable). Every reboot pulls the running VergeOS image from the cluster over PXE. Common pattern for diskless compute nodes |
 
 Both use the same underlying service: the provider cluster runs dnsmasq on a designated vNet and serves the VergeOS boot image over the network.
 

--- a/docs/implementation-guide/pxe-boot.md
+++ b/docs/implementation-guide/pxe-boot.md
@@ -279,4 +279,3 @@ Work through this list first when PXE isn't behaving. Most failures trace back t
 - [Connect VergeOS to an Existing LAN/WAN](https://docs.verge.io/product-guide/networks/connect-lan-wan/)
 - [Installation Guide](https://docs.verge.io/implementation-guide/installation-guide/)
 - [Scale-out Node Installation Guide](https://docs.verge.io/implementation-guide/scale-out-nodes/)
-- Docs issue for this guide: [verge-io/docs#435](https://github.com/verge-io/docs/issues/435)


### PR DESCRIPTION
## Summary

Adds a new page at `docs/implementation-guide/pxe-boot.md` covering end-to-end VergeOS PXE boot setup. Closes a long-standing gap where customers had to figure out PXE setup through trial and error.

## What's covered

**§1–2 Overview and Prerequisites** — Two distinct scenarios: first-time PXE install as a USB installer alternative, and every-boot PXE for diskless compute nodes. Prerequisites include native VLAN match (the #1 silent failure cause), dedicated PXE NIC recommendation, and "no competing DHCP on the segment" up front.

**§3 Configure VergeOS to serve PXE** — Step-by-step creation of the External vNet, DHCP settings (including safe gateway handling), setting the **PXE Boot** dropdown to `ybos`, and powering on the vNet.

**§4 Network considerations** — Dedicated install VLAN pattern, competing-DHCP warning, VLAN trunking, and dedicated-NIC vs bonded-externals tradeoff.

**§5 Configure the node to PXE boot** — States what must be true (PXE enabled, boot order, no competing device) but defers vendor-specific BIOS/BMC steps to the server documentation. Includes a section on managed / virtualized NIC platforms (blade chassis, converged infrastructure) for vNIC + boot policy configuration.

**§6 First-time install via PXE** — The boot menu flow and install type selection.

**§7 Every-boot PXE for diskless nodes** — Boot flow, considerations around cluster availability, and no-per-node-image-management.

**§8 Changing a node's NIC configuration (caution)** — Prominent warning that node identity is tied to the install-time MAC. Covers scenarios (NIC swap, vNIC rebuild, cable move), pre-change checklist, and two recovery options:
- Option 1: Refresh → Drives and NICs (running node)
- Option 2: Manually edit NIC MAC + reboot PXE network (downed node, same slot / new MAC)

**§9 Troubleshooting** — Common-things-to-verify checklist (13 diagnostic checkpoints) and a specific error codes table (PXE-E32, PXE-E53, PXE-MOF, etc.).

**§10 Related** — Links to Connect LAN/WAN, Installation Guide, Scale-out Node Guide.

## Scope note

Vendor-specific BIOS / UEFI / BMC configuration is intentionally out of scope. The guide states what must be true and defers the vendor how-to to server documentation. No Cisco UCS / Dell / HPE / Supermicro specifics.

## Source

Written based on real-world support engagements where the DHCP conflict and native-VLAN gotchas bit hard and silently. Guide is vendor-neutral and ready for review.