### PR TITLE
Add KB: Cluster Recovery After Full Power Outage (closes #441)

### DIFF
--- a/docs/knowledge-base/posts/cluster-recovery-after-power-outage.md
+++ b/docs/knowledge-base/posts/cluster-recovery-after-power-outage.md
@@ -1,9 +1,9 @@
 ---
 title: Cluster Recovery After Full Power Outage
-slug: cluster-recovery-after-full-power-outage
+slug: cluster-recovery-after-power-outage
 description: Recovery procedure and best practices for VergeOS clusters after an unplanned full power loss, including power-on order, vSAN integrity verification, and prevention guidance.
 author: Carl Rodabaugh
-draft: true
+draft: false
 date: 2026-04-27T00:00:00.000Z
 tags: [power-outage, recovery, vsan, cluster-management, troubleshooting, best-practices]
 categories:
@@ -19,7 +19,7 @@ dateCreated: 2026-04-27T00:00:00.000Z
 ## Overview
 
 !!! info "Key Points"
-    - Power on **Node1** first; it will boot to **"Waiting for the vSAN to mount"** and stop there until it sees a peer's vote. Once you see that prompt on Node1, power on **Node2**; once vSAN mounts, power on remaining nodes one at a time, ~1 minute apart
+    - Power on **Node1** first; it will boot but halt before mounting the vSAN until it sees a peer's vote. Once Node1 has reached that wait state, power on **Node2**; once vSAN mounts, power on remaining nodes one at a time, ~1 minute apart
     - In systems with more than 2 nodes, vSAN requires at least 2 nodes online for quorum -- storage will not mount until then
     - A non-zero **Repairs** count after recovery is normal; it should decrease as Journal Walks complete
     - Engage VergeIO Support before any destructive action if anomalies persist
@@ -41,7 +41,7 @@ This article covers recovery of a VergeOS cluster after an **unplanned full powe
 
 - VergeFS is designed to survive abrupt power loss. On controller startup it triggers a **Full Journal Walk** to verify each block and reconcile against peers.
 - Until at least 2 nodes are online, vSAN cannot establish quorum, storage will not mount, and VMs will not start.
-- Node1 will boot to **"Waiting for the vSAN to mount"** and stop there until Node2's vote arrives.
+- Node1 will boot but halt before mounting the vSAN until Node2's vote arrives.
 - Once quorum is reached, VergeOS handles vSAN reconciliation automatically -- no manual repair commands are needed.
 - A non-zero **Repairs** count after recovery is normal and should decrease as the Walk progresses. A non-zero **Bad Drives** count reflects drives missing since the current Walk began (typically nodes still coming up), not physical failures.
 
@@ -55,18 +55,18 @@ This article covers recovery of a VergeOS cluster after an **unplanned full powe
 ### Power-On Sequence
 
 1. **Power on Node1.**
-   - Watch the console/IPMI. Node1 will boot the OS but **stop at "Waiting for the vSAN to mount"** -- it cannot become the active controller on its own. It needs to see another controller node's vote before vSAN will mount.
-   - Do not power on other nodes yet. Wait until you see that prompt on Node1.
+   - Watch the console/IPMI. Node1 will boot the OS but **halt before mounting the vSAN** -- it cannot become the active controller on its own. It needs to see another controller node's vote before vSAN will mount.
+   - Do not power on other nodes yet. Wait until Node1 has reached that point.
 2. **Power on Node2.**
-   - Once Node2 boots far enough to register its vote, Node1's "Waiting for the vSAN to mount" message clears, vSAN mounts, and the cluster comes online.
+   - Once Node2 boots far enough to register its vote, Node1 proceeds, vSAN mounts, and the cluster comes online.
    - At this point the management UI becomes reachable.
 3. **Power on remaining nodes one at a time, approximately 1 minute apart.**
    - Sequential, paced power-on prevents resource contention and lets each node cleanly join the existing cluster.
    - You don't need to wait for each node to show Online before powering on the next -- the 1-minute spacing is enough.
-4. **Multi-cluster environments:** bring the controller cluster (containing Node1 and Node2) **fully online first**, then power on additional clusters using the same Node1 → wait-for-"Waiting for the vSAN to mount" → Node2 → remaining sequence within each.
+4. **Multi-cluster environments:** bring the controller cluster (containing Node1 and Node2) **fully online first**, then power on additional clusters using the same Node1 → wait-for-vSAN-mount → Node2 → remaining sequence within each.
 
 !!! tip "Pro Tip"
-    Node1 will sit at **"Waiting for the vSAN to mount"** until a peer (Node2) is online to provide a vote -- that's the signal it's ready for the next step, not a green dashboard. vSAN can't form quorum with only one controller, which is why the cluster won't come up until Node2 is also booting. Once quorum is reached, VergeOS handles vSAN reconciliation automatically; no manual repair commands are needed.
+    Node1 will sit and wait for a peer (Node2) before mounting the vSAN -- that wait state is the signal it's ready for the next step, not a green dashboard. vSAN can't form quorum with only one controller, which is why the cluster won't come up until Node2 is also booting. Once quorum is reached, VergeOS handles vSAN reconciliation automatically; no manual repair commands are needed.
 
 ### Post-Recovery Verification
 
@@ -106,7 +106,7 @@ This article covers recovery of a VergeOS cluster after an **unplanned full powe
     - **Problem:** Suspected split-brain or inconsistent cluster state.
       - **Solution:** If two subsets of nodes formed clusters independently during the outage (rare, but possible after prolonged network partitions), **do not attempt to merge them yourself**. Capture sysdiags from every node and engage support immediately.
 
-### Prevention
+## Prevention
 
 - **UPS sizing and coverage** -- size the UPS to cover graceful shutdown duration plus margin for every node. Include core network switches in the same coverage. Test UPS runtime annually -- batteries degrade.
 - **Automated graceful shutdown** -- VergeOS does not ship a built-in "shut down on power loss" signal, so this has to be driven externally. Use UPS management software (NUT, IPMI scripting, or your UPS vendor's agent on a management host) to detect a low-battery event and trigger a graceful cluster shutdown -- either via the Cluster Dashboard's **Power Off** action, the VergeOS API (`POST /v4/cluster_actions` with `action: shutdown`), or our [**VRG CLI**](https://github.com/verge-io/vrg) wrapper, which can script the same shutdown call from a Linux/macOS/Windows host. Validate the automation in a maintenance window before relying on it.
@@ -116,9 +116,9 @@ This article covers recovery of a VergeOS cluster after an **unplanned full powe
     - ***Power On*** -- VM powers on when power is restored, regardless of prior state
 - **Repair server (ioGuardian)** -- a configured [repair server](/product-guide/backup-dr/repair-server/) gives VergeFS a fallback source for missing blocks if peer nodes can't supply them after an outage. It pulls needed blocks from a synchronized remote VergeOS system and is built from an existing outgoing site sync configuration. Strongly recommended for any production deployment, and often auto-created when sites are added to the dashboard.
 - **Off-site snapshots** -- maintain replicated system snapshots at a remote site. If post-outage integrity issues require restoring data, a recent off-site copy is often the cleanest path back.
-- **Fencing (handled internally)** -- VergeOS doesn't expose Pacemaker-style STONITH because vSAN is shared-nothing: every block is redundantly stored, and writes require quorum. A partitioned node can't commit to the authoritative copy without the controller's vote, so split-brain corruption is prevented by design rather than by an external fencing agent. The operator-facing equivalents are **Maintenance Mode** (graceful) and **Kill Mode** (IPMI-driven hard power-off of an unresponsive node) -- both available from the node dashboard.
+- **Fencing (handled internally)** -- VergeOS doesn't expose Pacemaker-style STONITH because vSAN is shared-nothing: every block is redundantly stored, and writes require quorum. A partitioned node can't commit to the authoritative copy without the controller's vote, so split-brain corruption is prevented by design rather than by an external fencing agent. The operator-facing equivalents are [**Maintenance Mode**](/product-guide/operations/maintenance-mode/) (graceful) and an IPMI-driven hard power-off for an unresponsive node, both available from the node dashboard.
 
-### When to Engage Support
+## When to Engage Support
 
 Open a support case **before** taking destructive action if any of the following are true:
 
@@ -130,7 +130,7 @@ Open a support case **before** taking destructive action if any of the following
 - You suspect split-brain or inconsistent cluster state
 - Any node fails to rejoin and the cause isn't obviously hardware
 
-### Generating a System Diagnostic for Support
+## Generating a System Diagnostic for Support
 
 Before opening the case, capture a sysdiag and attach it (or send it directly to support):
 

--- a/docs/knowledge-base/posts/cluster-recovery-after-power-outage.md
+++ b/docs/knowledge-base/posts/cluster-recovery-after-power-outage.md
@@ -1,0 +1,164 @@
+---
+title: Cluster Recovery After Full Power Outage
+slug: cluster-recovery-after-full-power-outage
+description: Recovery procedure and best practices for VergeOS clusters after an unplanned full power loss, including power-on order, vSAN integrity verification, and prevention guidance.
+author: Carl Rodabaugh
+draft: true
+date: 2026-04-27T00:00:00.000Z
+tags: [power-outage, recovery, vsan, cluster-management, troubleshooting, best-practices]
+categories:
+  - System Administration
+  - Best Practices
+  - Troubleshooting
+editor: markdown
+dateCreated: 2026-04-27T00:00:00.000Z
+---
+
+# Cluster Recovery After Full Power Outage
+
+## Overview
+
+!!! info "Key Points"
+    - Power on **Node1** first; it will boot to **"Waiting for the vSAN to mount"** and stop there until it sees a peer's vote. Once you see that prompt on Node1, power on **Node2**; once vSAN mounts, power on remaining nodes one at a time, ~1 minute apart
+    - In systems with more than 2 nodes, vSAN requires at least 2 nodes online for quorum -- storage will not mount until then
+    - A non-zero **Repairs** count after recovery is normal; it should decrease as Journal Walks complete
+    - Engage VergeIO Support before any destructive action if anomalies persist
+
+This article covers recovery of a VergeOS cluster after an **unplanned full power loss** -- where every host went down at once and no graceful shutdown occurred. Following the correct sequence brings nodes back online safely, restores vSAN redundancy, and verifies integrity before workloads return to service. For a *planned* shutdown, see [Proper VergeOS System Shutdown Procedure](/knowledge-base/proper-vergeos-system-shutdown-procedure/).
+
+## Prerequisites
+
+- Physical or IPMI/BMC access to every node
+- Knowledge of which nodes are **Node1** and **Node2** (controller nodes)
+- Confirmation that upstream power, networking (core fabric switches), and IPMI are restored and stable
+- A recent backup or remote-replicated snapshot in case integrity issues are found
+- Familiarity with the [vSAN Tier Dashboard / Journal Walks](/knowledge-base/understanding-journal-walks-and-vsan-tier-status/)
+- Familiarity with [Proper Power Sequence](/knowledge-base/proper-power-sequence-for-vergeos/)
+
+## Steps
+
+### What to Expect
+
+- VergeFS is designed to survive abrupt power loss. On controller startup it triggers a **Full Journal Walk** to verify each block and reconcile against peers.
+- Until at least 2 nodes are online, vSAN cannot establish quorum, storage will not mount, and VMs will not start.
+- Node1 will boot to **"Waiting for the vSAN to mount"** and stop there until Node2's vote arrives.
+- Once quorum is reached, VergeOS handles vSAN reconciliation automatically -- no manual repair commands are needed.
+- A non-zero **Repairs** count after recovery is normal and should decrease as the Walk progresses. A non-zero **Bad Drives** count reflects drives missing since the current Walk began (typically nodes still coming up), not physical failures.
+
+### Pre-Power-On Checks
+
+1. Confirm **upstream power** is stable. Bringing nodes up on an unstable feed risks a second outage mid-recovery.
+2. Confirm **core network switches** are online and the inter-node fabric is up. vSAN cannot reform without it.
+3. Verify **IPMI/BMC** access on each node so you can monitor boot remotely if needed.
+4. Note any nodes with visible hardware faults (failed PSUs, drive LEDs, fan alarms) -- these may need attention before being added back.
+
+### Power-On Sequence
+
+1. **Power on Node1.**
+   - Watch the console/IPMI. Node1 will boot the OS but **stop at "Waiting for the vSAN to mount"** -- it cannot become the active controller on its own. It needs to see another controller node's vote before vSAN will mount.
+   - Do not power on other nodes yet. Wait until you see that prompt on Node1.
+2. **Power on Node2.**
+   - Once Node2 boots far enough to register its vote, Node1's "Waiting for the vSAN to mount" message clears, vSAN mounts, and the cluster comes online.
+   - At this point the management UI becomes reachable.
+3. **Power on remaining nodes one at a time, approximately 1 minute apart.**
+   - Sequential, paced power-on prevents resource contention and lets each node cleanly join the existing cluster.
+   - You don't need to wait for each node to show Online before powering on the next -- the 1-minute spacing is enough.
+4. **Multi-cluster environments:** bring the controller cluster (containing Node1 and Node2) **fully online first**, then power on additional clusters using the same Node1 → wait-for-"Waiting for the vSAN to mount" → Node2 → remaining sequence within each.
+
+!!! tip "Pro Tip"
+    Node1 will sit at **"Waiting for the vSAN to mount"** until a peer (Node2) is online to provide a vote -- that's the signal it's ready for the next step, not a green dashboard. vSAN can't form quorum with only one controller, which is why the cluster won't come up until Node2 is also booting. Once quorum is reached, VergeOS handles vSAN reconciliation automatically; no manual repair commands are needed.
+
+### Post-Recovery Verification
+
+1. **Verify vSAN health.**
+   - Open the **Main Dashboard** -- all stoplights should be **Green**.
+   - Navigate to **System → vSAN → Tiers** and double-click each tier.
+   - Review the **Status** tile:
+     - **Redundant**: should be `true`. May briefly show `false` while the Full Walk runs.
+     - **Full Walk**: typically `true` immediately after recovery (controller startup triggers one).
+     - **Walk Progress**: should advance over time.
+     - **Repairs**: should be decreasing. A non-zero value is expected after an unplanned outage -- VergeFS is rebuilding redundancy from peers.
+     - **Bad Drives**: should drop to `0` once all nodes are online. A non-zero value reflects drives missing since the current Walk began (typically tied to nodes still coming up), not physical failures.
+   - Allow Full Journal Walks to complete on every tier before declaring recovery complete.
+   - For a CLI/diagnostics view of the same data, use **System → vSAN Diagnostics → Get Tier Status** (and **Get Repair Status** to monitor active repairs). See the [vSAN Diagnostics Guide](/product-guide/storage/vsan-diagnostics/).
+2. **Verify drive health.**
+   - Go to **System → vSAN → Drives**.
+   - Look for any drives showing errors, warnings, or SMART alerts -- these can occur when drives don't return cleanly after abrupt power loss.
+   - Offline any drives with persistent errors and contact support before re-introducing them.
+3. **Verify workloads.**
+   - Confirm VMs auto-started per their **On Power Loss** settings.
+   - Spot-check critical VMs: console responsive, OS healthy, application services up.
+   - Review system logs (Main Dashboard) for errors during boot or initial mount.
+
+## Troubleshooting
+
+!!! warning "Common Issues"
+
+    - **Problem:** A node fails to rejoin the cluster.
+      - **Solution:** Check IPMI/console output for boot errors. Verify the node's core network interface is up and reachable from peers. Review **System → Nodes → [node]** for status and last-seen timestamps. If the node boots but does not join, do **not** force-remove it -- contact support.
+
+    - **Problem:** vSAN won't mount / storage offline.
+      - **Solution:** Confirm at least 2 nodes are **Online** under **System → Nodes**. Confirm inter-node connectivity (core fabric switches, link state, MTU). If quorum is met but storage still won't mount, capture a sysdiag and engage support.
+
+    - **Problem:** Repair count is stuck or growing.
+      - **Solution:** A small, decreasing **Repairs** count is normal post-recovery. A count that **stops decreasing** or **grows** indicates blocks vSAN cannot reconstruct from peers. **Do not reboot any nodes.** Engage support before taking remediation steps.
+
+    - **Problem:** Suspected split-brain or inconsistent cluster state.
+      - **Solution:** If two subsets of nodes formed clusters independently during the outage (rare, but possible after prolonged network partitions), **do not attempt to merge them yourself**. Capture sysdiags from every node and engage support immediately.
+
+### Prevention
+
+- **UPS sizing and coverage** -- size the UPS to cover graceful shutdown duration plus margin for every node. Include core network switches in the same coverage. Test UPS runtime annually -- batteries degrade.
+- **Automated graceful shutdown** -- VergeOS does not ship a built-in "shut down on power loss" signal, so this has to be driven externally. Use UPS management software (NUT, IPMI scripting, or your UPS vendor's agent on a management host) to detect a low-battery event and trigger a graceful cluster shutdown -- either via the Cluster Dashboard's **Power Off** action, the VergeOS API (`POST /v4/cluster_actions` with `action: shutdown`), or our [**VRG CLI**](https://github.com/verge-io/vrg) wrapper, which can script the same shutdown call from a Linux/macOS/Windows host. Validate the automation in a maintenance window before relying on it.
+- **"On Power Loss" VM settings** -- configure each VM's behavior deliberately so post-recovery state is predictable. Three options:
+    - ***Last State*** -- VM powers on only if it was on at the time of power loss
+    - ***Leave Off*** -- VM stays off when power is restored, regardless of prior state
+    - ***Power On*** -- VM powers on when power is restored, regardless of prior state
+- **Repair server (ioGuardian)** -- a configured [repair server](/product-guide/backup-dr/repair-server/) gives VergeFS a fallback source for missing blocks if peer nodes can't supply them after an outage. It pulls needed blocks from a synchronized remote VergeOS system and is built from an existing outgoing site sync configuration. Strongly recommended for any production deployment, and often auto-created when sites are added to the dashboard.
+- **Off-site snapshots** -- maintain replicated system snapshots at a remote site. If post-outage integrity issues require restoring data, a recent off-site copy is often the cleanest path back.
+- **Fencing (handled internally)** -- VergeOS doesn't expose Pacemaker-style STONITH because vSAN is shared-nothing: every block is redundantly stored, and writes require quorum. A partitioned node can't commit to the authoritative copy without the controller's vote, so split-brain corruption is prevented by design rather than by an external fencing agent. The operator-facing equivalents are **Maintenance Mode** (graceful) and **Kill Mode** (IPMI-driven hard power-off of an unresponsive node) -- both available from the node dashboard.
+
+### When to Engage Support
+
+Open a support case **before** taking destructive action if any of the following are true:
+
+- vSAN won't mount after at least 2 nodes are online and quorum should be met
+- A tier shows **Redundant: false** for an extended period after Full Walks complete
+- The **Repairs** count is stuck or growing
+- A stuck-repairs alert is present (VergeOS 26+)
+- Multiple drives report errors after recovery
+- You suspect split-brain or inconsistent cluster state
+- Any node fails to rejoin and the cause isn't obviously hardware
+
+### Generating a System Diagnostic for Support
+
+Before opening the case, capture a sysdiag and attach it (or send it directly to support):
+
+1. **Log in to the parent/root environment** -- sysdiags can't be generated from a tenant.
+2. Navigate to **System → System Diagnostics** and click **Build** (or **New Report**) on the left menu.
+3. Give the report a **Name** and **Description** so support can identify it.
+4. Check the box for **"Send diagnostic information to Verge.io support"** to upload directly. (For air-gapped systems, leave it unchecked, download the file once it finishes building, and email it to **support@verge.io** -- or use a file-sharing link if the file is too large for email.)
+5. Click **Submit**. The status moves from *Building* → *Sending to Support* → *Sent to Support* when complete.
+
+See [Generating System Diagnostics](/knowledge-base/generating-system-diagnostics/) and the full [System Diagnostics](/product-guide/system/diagnostics/) reference.
+
+## Additional Resources
+
+- [Proper Power Sequence](/knowledge-base/proper-power-sequence-for-vergeos/)
+- [Proper VergeOS System Shutdown Procedure](/knowledge-base/proper-vergeos-system-shutdown-procedure/)
+- [Understanding Journal Walks and vSAN Tier Status](/knowledge-base/understanding-journal-walks-and-vsan-tier-status/)
+- [Generating System Diagnostics](/knowledge-base/generating-system-diagnostics/)
+- [Repair Server (ioGuardian)](/product-guide/backup-dr/repair-server/)
+- [vSAN Diagnostics Guide](/product-guide/storage/vsan-diagnostics/)
+- [Sizing & Hardware Requirements](/implementation-guide/sizing/)
+
+## Feedback
+
+!!! question "Need Help?"
+    If you need further assistance or have any questions about this article, please don't hesitate to reach out to our support team.
+
+---
+
+!!! note "Document Information"
+    - Last Updated: 2026-04-27
+    - vergeOS Version: 26.0+

--- a/docs/knowledge-base/posts/cluster-recovery-after-power-outage.md
+++ b/docs/knowledge-base/posts/cluster-recovery-after-power-outage.md
@@ -19,8 +19,8 @@ dateCreated: 2026-04-27T00:00:00.000Z
 ## Overview
 
 !!! info "Key Points"
-    - Power on **Node1** first; it will boot but halt before mounting the vSAN until it sees a peer's vote. Once Node1 has reached that wait state, power on **Node2**; once vSAN mounts, power on remaining nodes one at a time, ~1 minute apart
-    - In systems with more than 2 nodes, vSAN requires at least 2 nodes online for quorum -- storage will not mount until then
+    - Power on **Node1** first; it will boot but halt before mounting the vSAN until enough peers join. Once Node1 has reached that wait state, power on the remaining nodes one at a time, ~1 minute apart
+    - vSAN mounts automatically once **N-1 vSAN nodes** are online: a 4-node cluster needs 3, a 6-node needs 5, an 8-node needs 7
     - A non-zero **Repairs** count after recovery is normal; it should decrease as Journal Walks complete
     - Engage VergeIO Support before any destructive action if anomalies persist
 
@@ -29,7 +29,7 @@ This article covers recovery of a VergeOS cluster after an **unplanned full powe
 ## Prerequisites
 
 - Physical or IPMI/BMC access to every node
-- Knowledge of which nodes are **Node1** and **Node2** (controller nodes)
+- Knowledge of which node is **Node1** (boot order matters) and which two nodes are the **controllers** (Node1 and Node2)
 - Confirmation that upstream power, networking (core fabric switches), and IPMI are restored and stable
 - A recent backup or remote-replicated snapshot in case integrity issues are found
 - Familiarity with the [vSAN Tier Dashboard / Journal Walks](/knowledge-base/understanding-journal-walks-and-vsan-tier-status/)
@@ -40,10 +40,10 @@ This article covers recovery of a VergeOS cluster after an **unplanned full powe
 ### What to Expect
 
 - VergeFS is designed to survive abrupt power loss. On controller startup it triggers a **Full Journal Walk** to verify each block and reconcile against peers.
-- Until at least 2 nodes are online, vSAN cannot establish quorum, storage will not mount, and VMs will not start.
-- Node1 will boot but halt before mounting the vSAN until Node2's vote arrives.
+- vSAN requires **N-1 vSAN nodes** online before it will mount. Until that threshold is reached, storage stays offline and VMs will not start.
+- Node1 will boot but halt before mounting the vSAN until enough peers join to satisfy N-1.
 - Once quorum is reached, VergeOS handles vSAN reconciliation automatically -- no manual repair commands are needed.
-- A non-zero **Repairs** count after recovery is normal and should decrease as the Walk progresses. A non-zero **Bad Drives** count reflects drives missing since the current Walk began (typically nodes still coming up), not physical failures.
+- A non-zero **Repairs** count after recovery is normal and should decrease as the Walk progresses.
 
 ### Pre-Power-On Checks
 
@@ -55,30 +55,26 @@ This article covers recovery of a VergeOS cluster after an **unplanned full powe
 ### Power-On Sequence
 
 1. **Power on Node1.**
-   - Watch the console/IPMI. Node1 will boot the OS but **halt before mounting the vSAN** -- it cannot become the active controller on its own. It needs to see another controller node's vote before vSAN will mount.
-   - Do not power on other nodes yet. Wait until Node1 has reached that point.
-2. **Power on Node2.**
-   - Once Node2 boots far enough to register its vote, Node1 proceeds, vSAN mounts, and the cluster comes online.
-   - At this point the management UI becomes reachable.
-3. **Power on remaining nodes one at a time, approximately 1 minute apart.**
+   - Watch the console/IPMI. Node1 will boot the OS but **halt before mounting the vSAN** until enough peers join to reach N-1.
+2. **Power on the remaining nodes, one at a time, approximately 1 minute apart.**
+   - vSAN mounts automatically as soon as N-1 nodes are up (3 of 4, 5 of 6, 7 of 8); the rest join cleanly as they come online.
    - Sequential, paced power-on prevents resource contention and lets each node cleanly join the existing cluster.
-   - You don't need to wait for each node to show Online before powering on the next -- the 1-minute spacing is enough.
-4. **Multi-cluster environments:** bring the controller cluster (containing Node1 and Node2) **fully online first**, then power on additional clusters using the same Node1 → wait-for-vSAN-mount → Node2 → remaining sequence within each.
+3. **Multi-cluster environments:** bring the controller cluster fully online before powering on additional clusters, using the same sequence within each.
 
 !!! tip "Pro Tip"
-    Node1 will sit and wait for a peer (Node2) before mounting the vSAN -- that wait state is the signal it's ready for the next step, not a green dashboard. vSAN can't form quorum with only one controller, which is why the cluster won't come up until Node2 is also booting. Once quorum is reached, VergeOS handles vSAN reconciliation automatically; no manual repair commands are needed.
+    Node1 boots first and sits waiting while you power on the rest of the cluster -- that's expected, not a stuck state. vSAN mounts on its own as soon as enough peers are online, and VergeOS handles reconciliation automatically; no manual repair commands are needed.
 
 ### Post-Recovery Verification
 
 1. **Verify vSAN health.**
-   - Open the **Main Dashboard** -- all stoplights should be **Green**.
+   - Open the **Main Dashboard** -- all status lights should be **Green**.
    - Navigate to **System → vSAN → Tiers** and double-click each tier.
    - Review the **Status** tile:
      - **Redundant**: should be `true`. May briefly show `false` while the Full Walk runs.
      - **Full Walk**: typically `true` immediately after recovery (controller startup triggers one).
      - **Walk Progress**: should advance over time.
      - **Repairs**: should be decreasing. A non-zero value is expected after an unplanned outage -- VergeFS is rebuilding redundancy from peers.
-     - **Bad Drives**: should drop to `0` once all nodes are online. A non-zero value reflects drives missing since the current Walk began (typically tied to nodes still coming up), not physical failures.
+     - **Bad Drives**: this is the count of drives the cluster currently can't see. It should drop to `0` once all nodes are fully Online and their drives have re-enumerated. If the count persists after every node is Online, treat it as a real fault and engage support before re-introducing the affected drives.
    - Allow Full Journal Walks to complete on every tier before declaring recovery complete.
    - For a CLI/diagnostics view of the same data, use **System → vSAN Diagnostics → Get Tier Status** (and **Get Repair Status** to monitor active repairs). See the [vSAN Diagnostics Guide](/product-guide/storage/vsan-diagnostics/).
 2. **Verify drive health.**
@@ -98,31 +94,31 @@ This article covers recovery of a VergeOS cluster after an **unplanned full powe
       - **Solution:** Check IPMI/console output for boot errors. Verify the node's core network interface is up and reachable from peers. Review **System → Nodes → [node]** for status and last-seen timestamps. If the node boots but does not join, do **not** force-remove it -- contact support.
 
     - **Problem:** vSAN won't mount / storage offline.
-      - **Solution:** Confirm at least 2 nodes are **Online** under **System → Nodes**. Confirm inter-node connectivity (core fabric switches, link state, MTU). If quorum is met but storage still won't mount, capture a sysdiag and engage support.
+      - **Solution:** Confirm **N-1 vSAN nodes are Online** under **System → Nodes** (e.g., 3 of 4 in a 4-node cluster, 5 of 6 in a 6-node cluster). Confirm inter-node connectivity (core fabric switches, link state, MTU). If the threshold is met but storage still won't mount, capture a sysdiag and engage support.
 
     - **Problem:** Repair count is stuck or growing.
       - **Solution:** A small, decreasing **Repairs** count is normal post-recovery. A count that **stops decreasing** or **grows** indicates blocks vSAN cannot reconstruct from peers. **Do not reboot any nodes.** Engage support before taking remediation steps.
 
     - **Problem:** Suspected split-brain or inconsistent cluster state.
-      - **Solution:** If two subsets of nodes formed clusters independently during the outage (rare, but possible after prolonged network partitions), **do not attempt to merge them yourself**. Capture sysdiags from every node and engage support immediately.
+      - **Solution:** During recovery a network problem can cause two subsets of nodes to come up unable to see each other. If you see signs of two independent clusters forming (rare, but possible after partial network restoration), **do not attempt to merge them yourself**. Capture sysdiags from every node and engage support immediately.
 
 ## Prevention
 
 - **UPS sizing and coverage** -- size the UPS to cover graceful shutdown duration plus margin for every node. Include core network switches in the same coverage. Test UPS runtime annually -- batteries degrade.
-- **Automated graceful shutdown** -- VergeOS does not ship a built-in "shut down on power loss" signal, so this has to be driven externally. Use UPS management software (NUT, IPMI scripting, or your UPS vendor's agent on a management host) to detect a low-battery event and trigger a graceful cluster shutdown -- either via the Cluster Dashboard's **Power Off** action, the VergeOS API (`POST /v4/cluster_actions` with `action: shutdown`), or our [**VRG CLI**](https://github.com/verge-io/vrg) wrapper, which can script the same shutdown call from a Linux/macOS/Windows host. Validate the automation in a maintenance window before relying on it.
+- **Automated graceful shutdown** -- VergeOS does not currently document a built-in UPS/NUT integration, so graceful-shutdown automation has to be driven externally. Use UPS management software (NUT, IPMI scripting, or your UPS vendor's agent on a management host) to detect a low-battery event and trigger a graceful cluster shutdown -- either via the Cluster Dashboard's **Power Off** action, the VergeOS API (`POST /v4/cluster_actions` with body `{"cluster": <cluster_id>, "action": "shutdown", "params": "{}"}`), or our [**VRG CLI**](https://github.com/verge-io/vrg) wrapper, which can script the same shutdown call from a Linux/macOS/Windows host. Validate the automation in a maintenance window before relying on it.
 - **"On Power Loss" VM settings** -- configure each VM's behavior deliberately so post-recovery state is predictable. Three options:
     - ***Last State*** -- VM powers on only if it was on at the time of power loss
     - ***Leave Off*** -- VM stays off when power is restored, regardless of prior state
     - ***Power On*** -- VM powers on when power is restored, regardless of prior state
-- **Repair server (ioGuardian)** -- a configured [repair server](/product-guide/backup-dr/repair-server/) gives VergeFS a fallback source for missing blocks if peer nodes can't supply them after an outage. It pulls needed blocks from a synchronized remote VergeOS system and is built from an existing outgoing site sync configuration. Strongly recommended for any production deployment, and often auto-created when sites are added to the dashboard.
+- **Repair server (ioGuardian)** -- a configured [repair server](/product-guide/backup-dr/repair-server/) gives VergeFS a fallback source for missing blocks if peer nodes can't supply them after an outage. It pulls needed blocks from a synchronized remote VergeOS system and is built from an existing outgoing site sync configuration. Strongly recommended for any production deployment.
 - **Off-site snapshots** -- maintain replicated system snapshots at a remote site. If post-outage integrity issues require restoring data, a recent off-site copy is often the cleanest path back.
-- **Fencing (handled internally)** -- VergeOS doesn't expose Pacemaker-style STONITH because vSAN is shared-nothing: every block is redundantly stored, and writes require quorum. A partitioned node can't commit to the authoritative copy without the controller's vote, so split-brain corruption is prevented by design rather than by an external fencing agent. The operator-facing equivalents are [**Maintenance Mode**](/product-guide/operations/maintenance-mode/) (graceful) and an IPMI-driven hard power-off for an unresponsive node, both available from the node dashboard.
+- **Fencing (handled internally)** -- VergeOS doesn't expose Pacemaker-style STONITH because vSAN is shared-nothing: every block is redundantly stored, and writes require quorum. A partitioned node can't commit to the authoritative copy without satisfying N-1, so split-brain corruption is prevented by design rather than by an external fencing agent. The operator-facing equivalents are [**Maintenance Mode**](/product-guide/operations/maintenance-mode/) (graceful) and an IPMI-driven hard power-off for an unresponsive node, both available from the node dashboard.
 
 ## When to Engage Support
 
 Open a support case **before** taking destructive action if any of the following are true:
 
-- vSAN won't mount after at least 2 nodes are online and quorum should be met
+- vSAN won't mount after N-1 nodes are online and quorum should be met
 - A tier shows **Redundant: false** for an extended period after Full Walks complete
 - The **Repairs** count is stuck or growing
 - A stuck-repairs alert is present (VergeOS 26+)
@@ -160,5 +156,5 @@ See [Generating System Diagnostics](/knowledge-base/generating-system-diagnostic
 ---
 
 !!! note "Document Information"
-    - Last Updated: 2026-04-27
+    - Last Updated: 2026-05-08
     - vergeOS Version: 26.0+

--- a/docs/knowledge-base/posts/cluster-recovery-after-power-outage.md
+++ b/docs/knowledge-base/posts/cluster-recovery-after-power-outage.md
@@ -14,17 +14,25 @@ editor: markdown
 dateCreated: 2026-04-27T00:00:00.000Z
 ---
 
+
 # Cluster Recovery After Full Power Outage
 
 ## Overview
 
 !!! info "Key Points"
-    - Power on **Node1** first; it will boot but halt before mounting the vSAN until enough peers join. Once Node1 has reached that wait state, power on the remaining nodes one at a time, ~1 minute apart
-    - vSAN mounts automatically once **N-1 vSAN nodes** are online: a 4-node cluster needs 3, a 6-node needs 5, an 8-node needs 7
+    - Ungraceful shutdowns should be avoided where possible, particularly on production systems. 
+    - This guide provides best practices - to mitigate potential problems - for powering on a the cluster after an unexpected shutdown does occur 
+    - Power on **Node1** first. Wait 30 seconds to a minute, then power on all remaining nodes
     - A non-zero **Repairs** count after recovery is normal; it should decrease as Journal Walks complete
-    - Engage VergeIO Support before any destructive action if anomalies persist
+    - Engage VergeIO Support when anomalies persist
 
-This article covers recovery of a VergeOS cluster after an **unplanned full power loss** -- where every host went down at once and no graceful shutdown occurred. Following the correct sequence brings nodes back online safely, restores vSAN redundancy, and verifies integrity before workloads return to service. For a *planned* shutdown, see [Proper VergeOS System Shutdown Procedure](/knowledge-base/proper-vergeos-system-shutdown-procedure/).
+## Scope
+
+This guide covers powering a VergeOS cluster back on after an **ungraceful shutdown** -- where the cluster lost power abruptly due to a power outage, UPS exhaustion, facility failure, or similar event. For planned, controlled shutdown and power-on procedures, see [Proper Power Sequence](/knowledge-base/proper-power-sequence-for-vergeos/) and [Proper VergeOS System Shutdown Procedure](/knowledge-base/proper-vergeos-system-shutdown-procedure/).
+
+!!! warning "Avoid Ungraceful Shutdowns Where Possible"
+    While VergeOS includes multiple built-in protections to preserve data integrity, no distributed storage system can fully guarantee against data corruption when nodes lose power abruptly and simultaneously. Writes in flight at the moment of power loss may be incomplete or inconsistent across peers, and in some cases the only path back to integrity is rolling a volume back to a recent snapshot.  Additionallly, hardware, guest OS and application problems are  common after ungraceful shutdowns. Proper power infrastructure -- UPS coverage sized for graceful shutdown, redundant PSUs, and automated shutdown on low-battery -- is the most effective protection; see the [Prevention](#prevention) section for guidance. When an ungraceful shutdown does occur despite these precautions, the procedure that follows is designed to bring the cluster back online safely and surface any integrity issues that need attention.
+
 
 ## Prerequisites
 
@@ -33,58 +41,77 @@ This article covers recovery of a VergeOS cluster after an **unplanned full powe
 - Confirmation that upstream power, networking (core fabric switches), and IPMI are restored and stable
 - A recent backup or remote-replicated snapshot in case integrity issues are found
 - Familiarity with the [vSAN Tier Dashboard / Journal Walks](/knowledge-base/understanding-journal-walks-and-vsan-tier-status/)
-- Familiarity with [Proper Power Sequence](/knowledge-base/proper-power-sequence-for-vergeos/)
+
 
 ## Steps
 
 ### What to Expect
 
-- VergeFS is designed to survive abrupt power loss. On controller startup it triggers a **Full Journal Walk** to verify each block and reconcile against peers.
+- VergeFS includes multiple built-in protections to help preserve data integrity during power events -- including write journaling, peer replication, repair servers(ioGuardian), and on-startup verification. On controller startup, VergeFS triggers a **Full Journal Walk** to verify each block and reconcile against peers. These protections are effective in most cases, but no distributed storage system can fully guarantee against corruption from abrupt power loss; verification after startup is important, especially after an ungraceful shutdown.
 - vSAN requires **N-1 vSAN nodes** online before it will mount. Until that threshold is reached, storage stays offline and VMs will not start.
 - Node1 will boot but halt before mounting the vSAN until enough peers join to satisfy N-1.
-- Once quorum is reached, VergeOS handles vSAN reconciliation automatically -- no manual repair commands are needed.
 - A non-zero **Repairs** count after recovery is normal and should decrease as the Walk progresses.
 
 ### Pre-Power-On Checks
 
+!!! warning "Verify Infrastructure Is Ready First"
+    Before powering on any cluster nodes, confirm two critical conditions are met. These are covered in the prerequisites, but they bear repeating here -- skipping them can cause significantly more damage than the original shutdown:
+
+    1. **Facility power is fully restored and stable.** Bringing the cluster up during ongoing power instability -- flickers, brownouts, or a second outage -- risks compounding the original problem and can lead to further data integrity issues.
+    2. **Core network switches are powered on and fully booted.** Enterprise switches can take several minutes to complete their boot process, similar to a server. If cluster nodes come online before the network is ready, they will be unable to discover their peers, which can cause reconciliation problems.
+
 1. Confirm **upstream power** is stable. Bringing nodes up on an unstable feed risks a second outage mid-recovery.
-2. Confirm **core network switches** are online and the inter-node fabric is up. vSAN cannot reform without it.
+2. Confirm **core network switches** are online, **fully booted**, and the inter-node fabric is up. vSAN cannot reform without it, and advanced switches can take several minutes to finish booting.
 3. Verify **IPMI/BMC** access on each node so you can monitor boot remotely if needed.
 4. Note any nodes with visible hardware faults (failed PSUs, drive LEDs, fan alarms) -- these may need attention before being added back.
 
 ### Power-On Sequence
 
+Once power and network infrastructure are confirmed ready:
+
 1. **Power on Node1.**
    - Watch the console/IPMI. Node1 will boot the OS but **halt before mounting the vSAN** until enough peers join to reach N-1.
-2. **Power on the remaining nodes, one at a time, approximately 1 minute apart.**
-   - vSAN mounts automatically as soon as N-1 nodes are up (3 of 4, 5 of 6, 7 of 8); the rest join cleanly as they come online.
-   - Sequential, paced power-on prevents resource contention and lets each node cleanly join the existing cluster.
-3. **Multi-cluster environments:** bring the controller cluster fully online before powering on additional clusters, using the same sequence within each.
+2. **Wait 30 seconds to a minute.**
+   - This brief pause lets Node1 begin initializing before the rest of the cluster arrives. There is no need to wait for Node1 to fully reach its halt state before proceeding. 
+3. **Power on the remaining nodes.**
+   - The remaining nodes can be powered on together (or in close succession); there is no need to stagger them one at a time.
+   - The vSAN mounts automatically as soon as a minimum number of nodes are up (e.g. N-1 in a default N+1 configuration).
+4. **Multi-cluster environments:** bring the controller cluster fully online before powering on additional clusters.  
 
 !!! tip "Pro Tip"
     Node1 boots first and sits waiting while you power on the rest of the cluster -- that's expected, not a stuck state. vSAN mounts on its own as soon as enough peers are online, and VergeOS handles reconciliation automatically; no manual repair commands are needed.
 
 ### Post-Recovery Verification
 
-1. **Verify vSAN health.**
+Once all nodes are online and the cluster has had time to settle, verify that everything returned to a healthy state. Because the cluster was shut down ungracefully, perform these checks with heightened scrutiny -- abrupt power loss can leave behind issues that the cluster cannot fully resolve on its own. Look closely for persistent vSAN errors, failed or crash-looping workloads, and any guest-level filesystem errors. If unresolvable corruption is detected, rolling a volume back to a recent snapshot may be required.
+
+1. **Confirm Overall system health**  
+   Abrupt power loss increases the risk of hardware problems.  It is important to check for any issues:
+   - Review the [Alarms](/product-guide/operations/alarms) dashboard**.  Confirm no new alarms have been triggered. 
+   - Review system logs (Main Dashboard) for errors during boot or initial mount.  
+2. **Verify vSAN health**
    - Open the **Main Dashboard** -- all status lights should be **Green**.
    - Navigate to **System → vSAN → Tiers** and double-click each tier.
-   - Review the **Status** tile:
-     - **Redundant**: should be `true`. May briefly show `false` while the Full Walk runs.
-     - **Full Walk**: typically `true` immediately after recovery (controller startup triggers one).
-     - **Walk Progress**: should advance over time.
-     - **Repairs**: should be decreasing. A non-zero value is expected after an unplanned outage -- VergeFS is rebuilding redundancy from peers.
-     - **Bad Drives**: this is the count of drives the cluster currently can't see. It should drop to `0` once all nodes are fully Online and their drives have re-enumerated. If the count persists after every node is Online, treat it as a real fault and engage support before re-introducing the affected drives.
-   - Allow Full Journal Walks to complete on every tier before declaring recovery complete.
-   - For a CLI/diagnostics view of the same data, use **System → vSAN Diagnostics → Get Tier Status** (and **Get Repair Status** to monitor active repairs). See the [vSAN Diagnostics Guide](/product-guide/storage/vsan-diagnostics/).
-2. **Verify drive health.**
+   - Review the **Status** tile on each tier's dashboard.  The KB article: [Understanding vSAN Tier Status/Journal Walks](/product-guide/storage/vsan-diagnostics/) provides a guide for reading vSAN tier status fields.
+3. **Verify drive health**
    - Go to **System → vSAN → Drives**.
    - Look for any drives showing errors, warnings, or SMART alerts -- these can occur when drives don't return cleanly after abrupt power loss.
-   - Offline any drives with persistent errors and contact support before re-introducing them.
-3. **Verify workloads.**
-   - Confirm VMs auto-started per their **On Power Loss** settings.
-   - Spot-check critical VMs: console responsive, OS healthy, application services up.
-   - Review system logs (Main Dashboard) for errors during boot or initial mount.
+   - Faulty drives should be replaced expediently to maintain vSAN data protection.
+4. **Verify workloads**
+
+    !!! tip "VM Auto-Start Behavior"
+        By default, VMs are configured to auto-start when power is restored to the cluster. VMs with an alternate **On Power Loss** setting will need to be powered on manually.
+
+    - Verify critical VMs: console responsive, guest OS healthy, application services up. Ungraceful shutdowns can cause problems in the guest OS and installed applications -- watch for filesystem errors, services that fail to start, and applications that crash on launch.
+
+!!! warning "Snapshot Rollback Decisions Are Time-Sensitive"
+    If a VM shows signs of damage from the ungraceful shutdown that cannot be repaired in place, restoring from a pre-outage snapshot may be the only path back to a healthy state. **This determination should be made as promptly as possible**, for two reasons:
+
+    - **Snapshot retention is finite.** A viable pre-outage snapshot may roll off and become unavailable if too much time passes before the decision is made.
+    - **Newer data is lost on rollback.** The longer the affected VM stays in production use after the outage, the more legitimate post-recovery work is discarded when the rollback is performed.
+
+    Identify potential rollback candidates as early as possible -- ideally before applications return to heavy use.
+
 
 ## Troubleshooting
 
@@ -102,23 +129,23 @@ This article covers recovery of a VergeOS cluster after an **unplanned full powe
     - **Problem:** Suspected split-brain or inconsistent cluster state.
       - **Solution:** During recovery a network problem can cause two subsets of nodes to come up unable to see each other. If you see signs of two independent clusters forming (rare, but possible after partial network restoration), **do not attempt to merge them yourself**. Capture sysdiags from every node and engage support immediately.
 
-## Prevention
+## Prevention/Mitigation
 
 - **UPS sizing and coverage** -- size the UPS to cover graceful shutdown duration plus margin for every node. Include core network switches in the same coverage. Test UPS runtime annually -- batteries degrade.
-- **Automated graceful shutdown** -- VergeOS does not currently document a built-in UPS/NUT integration, so graceful-shutdown automation has to be driven externally. Use UPS management software (NUT, IPMI scripting, or your UPS vendor's agent on a management host) to detect a low-battery event and trigger a graceful cluster shutdown -- either via the Cluster Dashboard's **Power Off** action, the VergeOS API (`POST /v4/cluster_actions` with body `{"cluster": <cluster_id>, "action": "shutdown", "params": "{}"}`), or our [**VRG CLI**](https://github.com/verge-io/vrg) wrapper, which can script the same shutdown call from a Linux/macOS/Windows host. Validate the automation in a maintenance window before relying on it.
+- **Automated graceful shutdown** -- Use UPS management software (NUT, IPMI scripting, or your UPS vendor's agent on a management host) to detect a low-battery event and trigger a graceful cluster shutdown -- either via the Cluster Dashboard's **Power Off** action, the VergeOS API (`POST /v4/cluster_actions` with body `{"cluster": <cluster_id>, "action": "shutdown", "params": "{}"}`), or our [**VRG CLI**](https://github.com/verge-io/vrg) wrapper, which can script the same shutdown call from a Linux/macOS/Windows host. Validate the automation in a maintenance window before relying on it.
 - **"On Power Loss" VM settings** -- configure each VM's behavior deliberately so post-recovery state is predictable. Three options:
     - ***Last State*** -- VM powers on only if it was on at the time of power loss
     - ***Leave Off*** -- VM stays off when power is restored, regardless of prior state
     - ***Power On*** -- VM powers on when power is restored, regardless of prior state
-- **Repair server (ioGuardian)** -- a configured [repair server](/product-guide/backup-dr/repair-server/) gives VergeFS a fallback source for missing blocks if peer nodes can't supply them after an outage. It pulls needed blocks from a synchronized remote VergeOS system and is built from an existing outgoing site sync configuration. Strongly recommended for any production deployment.
-- **Off-site snapshots** -- maintain replicated system snapshots at a remote site. If post-outage integrity issues require restoring data, a recent off-site copy is often the cleanest path back.
-- **Fencing (handled internally)** -- VergeOS doesn't expose Pacemaker-style STONITH because vSAN is shared-nothing: every block is redundantly stored, and writes require quorum. A partitioned node can't commit to the authoritative copy without satisfying N-1, so split-brain corruption is prevented by design rather than by an external fencing agent. The operator-facing equivalents are [**Maintenance Mode**](/product-guide/operations/maintenance-mode/) (graceful) and an IPMI-driven hard power-off for an unresponsive node, both available from the node dashboard.
+- **Repair server (ioGuardian)** -- a configured [repair server](/product-guide/backup-dr/repair-server/) gives VergeFS a fallback source for missing blocks if peer nodes can't supply them after an outage. It pulls needed blocks from a synchronized remote VergeOS system and is built from an existing outgoing site sync configuration. Repair servers are trongly recommended for any production deployment.
+- **Adequate snapshot rotation** -- maintain a snapshot retention schedule that keeps recent, pre-event snapshots available for rollback when needed. Replicating snapshots to a remote site is also recommended as part of a comprehensive data protection strategy.
+
 
 ## When to Engage Support
 
-Open a support case **before** taking destructive action if any of the following are true:
+Open a support case **before** rebooting nodes if any of the following are true:
 
-- vSAN won't mount after N-1 nodes are online and quorum should be met
+- vSAN won't mount after N nodes are online (e.g. N-1 nodes in a default N+1 redundancy)
 - A tier shows **Redundant: false** for an extended period after Full Walks complete
 - The **Repairs** count is stuck or growing
 - A stuck-repairs alert is present (VergeOS 26+)
@@ -129,12 +156,6 @@ Open a support case **before** taking destructive action if any of the following
 ## Generating a System Diagnostic for Support
 
 Before opening the case, capture a sysdiag and attach it (or send it directly to support):
-
-1. **Log in to the parent/root environment** -- sysdiags can't be generated from a tenant.
-2. Navigate to **System → System Diagnostics** and click **Build** (or **New Report**) on the left menu.
-3. Give the report a **Name** and **Description** so support can identify it.
-4. Check the box for **"Send diagnostic information to Verge.io support"** to upload directly. (For air-gapped systems, leave it unchecked, download the file once it finishes building, and email it to **support@verge.io** -- or use a file-sharing link if the file is too large for email.)
-5. Click **Submit**. The status moves from *Building* → *Sending to Support* → *Sent to Support* when complete.
 
 See [Generating System Diagnostics](/knowledge-base/generating-system-diagnostics/) and the full [System Diagnostics](/product-guide/system/diagnostics/) reference.
 

--- a/docs/knowledge-base/posts/cluster-recovery-after-power-outage.md
+++ b/docs/knowledge-base/posts/cluster-recovery-after-power-outage.md
@@ -20,18 +20,22 @@ dateCreated: 2026-04-27T00:00:00.000Z
 ## Overview
 
 !!! info "Key Points"
-    - Ungraceful shutdowns should be avoided where possible, particularly on production systems. 
-    - This guide provides best practices - to mitigate potential problems - for powering on a the cluster after an unexpected shutdown does occur 
-    - Power on **Node1** first. Wait 30 seconds to a minute, then power on all remaining nodes
-    - A non-zero **Repairs** count after recovery is normal; it should decrease as Journal Walks complete
-    - Engage VergeIO Support when anomalies persist
+    - Ungraceful shutdowns should be avoided where possible, particularly on production systems.
+    - This guide provides best practices -- to mitigate potential problems -- for powering on the cluster after an unexpected shutdown does occur.
+    - Power on **Node1** first. Wait 30 seconds to a minute, then power on remaining cluster nodes.
+    - A non-zero **Repairs** count after recovery is normal; it should decrease as Journal Walks complete.
+    - Engage VergeIO Support when anomalies persist.
 
 ## Scope
 
 This guide covers powering a VergeOS cluster back on after an **ungraceful shutdown** -- where the cluster lost power abruptly due to a power outage, UPS exhaustion, facility failure, or similar event. For planned, controlled shutdown and power-on procedures, see [Proper Power Sequence](/knowledge-base/proper-power-sequence-for-vergeos/) and [Proper VergeOS System Shutdown Procedure](/knowledge-base/proper-vergeos-system-shutdown-procedure/).
 
 !!! warning "Avoid Ungraceful Shutdowns Where Possible"
-    While VergeOS includes multiple built-in protections to preserve data integrity, no distributed storage system can fully guarantee against data corruption when nodes lose power abruptly and simultaneously. Writes in flight at the moment of power loss may be incomplete or inconsistent across peers, and in some cases the only path back to integrity is rolling a volume back to a recent snapshot.  Additionallly, hardware, guest OS and application problems are  common after ungraceful shutdowns. Proper power infrastructure -- UPS coverage sized for graceful shutdown, redundant PSUs, and automated shutdown on low-battery -- is the most effective protection; see the [Prevention](#prevention) section for guidance. When an ungraceful shutdown does occur despite these precautions, the procedure that follows is designed to bring the cluster back online safely and surface any integrity issues that need attention.
+    * While VergeOS includes multiple built-in protections to preserve data integrity, no distributed storage system can fully guarantee against data corruption when nodes lose power abruptly and simultaneously. 
+    * Writes in flight at the moment of power loss may be incomplete or inconsistent across peers, and in some cases the only path back to integrity is rolling a volume back to a recent snapshot.  
+    * Additionally, hardware, guest OS, and application problems are common after ungraceful shutdowns.   
+    * Proper power infrastructure -- UPS coverage sized for graceful shutdown, redundant PSUs, and automated shutdown on low-battery -- is the most effective protection; see the [Prevention](#prevention) section for guidance.  
+    * When an ungraceful shutdown does occur despite these precautions, the procedure that follows is designed to bring the cluster back online safely and surface any integrity issues that need attention.
 
 
 ## Prerequisites
@@ -39,7 +43,7 @@ This guide covers powering a VergeOS cluster back on after an **ungraceful shutd
 - Physical or IPMI/BMC access to every node
 - Knowledge of which node is **Node1** (boot order matters) and which two nodes are the **controllers** (Node1 and Node2)
 - Confirmation that upstream power, networking (core fabric switches), and IPMI are restored and stable
-- A recent backup or remote-replicated snapshot in case integrity issues are found
+- A recent local or remote-replicated snapshot in case integrity issues are found
 - Familiarity with the [vSAN Tier Dashboard / Journal Walks](/knowledge-base/understanding-journal-walks-and-vsan-tier-status/)
 
 
@@ -47,7 +51,7 @@ This guide covers powering a VergeOS cluster back on after an **ungraceful shutd
 
 ### What to Expect
 
-- VergeFS includes multiple built-in protections to help preserve data integrity during power events -- including write journaling, peer replication, repair servers(ioGuardian), and on-startup verification. On controller startup, VergeFS triggers a **Full Journal Walk** to verify each block and reconcile against peers. These protections are effective in most cases, but no distributed storage system can fully guarantee against corruption from abrupt power loss; verification after startup is important, especially after an ungraceful shutdown.
+- VergeFS includes multiple built-in protections to help preserve data integrity during power events -- including write journaling, peer replication, repair servers (ioGuardian), and on-startup verification. On controller startup, VergeFS triggers a **Full Journal Walk** to verify each block and reconcile against peers. These protections are effective in most cases, but no distributed storage system can fully guarantee against corruption from abrupt power loss; verification after startup is important, especially after an ungraceful shutdown.
 - vSAN requires **N-1 vSAN nodes** online before it will mount. Until that threshold is reached, storage stays offline and VMs will not start.
 - Node1 will boot but halt before mounting the vSAN until enough peers join to satisfy N-1.
 - A non-zero **Repairs** count after recovery is normal and should decrease as the Walk progresses.
@@ -69,48 +73,50 @@ This guide covers powering a VergeOS cluster back on after an **ungraceful shutd
 
 Once power and network infrastructure are confirmed ready:
 
-1. **Power on Node1.**
+1. **Power on Node1.**  
    - Watch the console/IPMI. Node1 will boot the OS but **halt before mounting the vSAN** until enough peers join to reach N-1.
-2. **Wait 30 seconds to a minute.**
+2. **Wait 30 seconds to a minute.**  
    - This brief pause lets Node1 begin initializing before the rest of the cluster arrives. There is no need to wait for Node1 to fully reach its halt state before proceeding. 
-3. **Power on the remaining nodes.**
-   - The remaining nodes can be powered on together (or in close succession); there is no need to stagger them one at a time.
+3. **Power on the remaining nodes.**  
+   - The remaining nodes can be powered on together (or in close succession); there is no need to stagger them one at a time.    
    - The vSAN mounts automatically as soon as a minimum number of nodes are up (e.g. N-1 in a default N+1 configuration).
-4. **Multi-cluster environments:** bring the controller cluster fully online before powering on additional clusters.  
+4. **Multi-cluster environments:** bring the controller cluster fully online before powering on additional clusters.
 
 !!! tip "Pro Tip"
-    Node1 boots first and sits waiting while you power on the rest of the cluster -- that's expected, not a stuck state. vSAN mounts on its own as soon as enough peers are online, and VergeOS handles reconciliation automatically; no manual repair commands are needed.
+    Node1 boots first and sits waiting while you power on the rest of the cluster -- that's expected, not a stuck state. The vSAN mounts on its own as soon as enough peers are online, and VergeOS handles reconciliation automatically; no manual repair commands are needed.
 
 ### Post-Recovery Verification
 
 Once all nodes are online and the cluster has had time to settle, verify that everything returned to a healthy state. Because the cluster was shut down ungracefully, perform these checks with heightened scrutiny -- abrupt power loss can leave behind issues that the cluster cannot fully resolve on its own. Look closely for persistent vSAN errors, failed or crash-looping workloads, and any guest-level filesystem errors. If unresolvable corruption is detected, rolling a volume back to a recent snapshot may be required.
 
-1. **Confirm Overall system health**  
-   Abrupt power loss increases the risk of hardware problems.  It is important to check for any issues:
-   - Review the [Alarms](/product-guide/operations/alarms) dashboard**.  Confirm no new alarms have been triggered. 
-   - Review system logs (Main Dashboard) for errors during boot or initial mount.  
+1. **Confirm overall system health**
+    Abrupt power loss increases the risk of hardware problems. It is important to check for any issues:
+
+    - Review the [Alarms](/product-guide/operations/alarms/) dashboard. Confirm no new alarms have been triggered.
+    - Review **system logs (Main Dashboard)** for errors during boot or initial mount.
+
 2. **Verify vSAN health**
-   - Open the **Main Dashboard** -- all status lights should be **Green**.
-   - Navigate to **System → vSAN → Tiers** and double-click each tier.
-   - Review the **Status** tile on each tier's dashboard.  The KB article: [Understanding vSAN Tier Status/Journal Walks](/product-guide/storage/vsan-diagnostics/) provides a guide for reading vSAN tier status fields.
+    - Open the **Main Dashboard** -- all status lights should be **Green**.
+    - Navigate to **System → vSAN → Tiers** and double-click each tier.
+    - Review the **Status** tile on each tier's dashboard. The KB article [Understanding vSAN Tier Status/Journal Walks](/product-guide/storage/vsan-diagnostics/) provides a guide for reading vSAN tier status fields.
 3. **Verify drive health**
-   - Go to **System → vSAN → Drives**.
-   - Look for any drives showing errors, warnings, or SMART alerts -- these can occur when drives don't return cleanly after abrupt power loss.
-   - Faulty drives should be replaced expediently to maintain vSAN data protection.
+    - Go to **System → vSAN → Drives**.
+    - Look for any drives showing errors, warnings, or SMART alerts -- these can occur when drives don't return cleanly after abrupt power loss.
+    - **Replace faulty drives** expediently to maintain vSAN data protection.
+
 4. **Verify workloads**
 
     !!! tip "VM Auto-Start Behavior"
         By default, VMs are configured to auto-start when power is restored to the cluster. VMs with an alternate **On Power Loss** setting will need to be powered on manually.
 
-    - Verify critical VMs: console responsive, guest OS healthy, application services up. Ungraceful shutdowns can cause problems in the guest OS and installed applications -- watch for filesystem errors, services that fail to start, and applications that crash on launch.
+    - Verify critical VMs: console responsive, guest OS healthy, application services up. Ungraceful shutdowns can cause problems within the guest OS and installed applications -- watch for filesystem errors, services that fail to start, and applications that crash on launch.
+    - Identify potential rollback candidates as early as possible -- ideally before applications return to heavy use.
 
 !!! warning "Snapshot Rollback Decisions Are Time-Sensitive"
-    If a VM shows signs of damage from the ungraceful shutdown that cannot be repaired in place, restoring from a pre-outage snapshot may be the only path back to a healthy state. **This determination should be made as promptly as possible**, for two reasons:
+    If the overall system or individual VMs show signs of damage from the ungraceful shutdown that cannot be repaired in place, restoring from a pre-outage snapshot may be the only path back to a healthy state. **This determination should be made as promptly as possible**, for two reasons:
 
     - **Snapshot retention is finite.** A viable pre-outage snapshot may roll off and become unavailable if too much time passes before the decision is made.
     - **Newer data is lost on rollback.** The longer the affected VM stays in production use after the outage, the more legitimate post-recovery work is discarded when the rollback is performed.
-
-    Identify potential rollback candidates as early as possible -- ideally before applications return to heavy use.
 
 
 ## Troubleshooting
@@ -137,18 +143,18 @@ Once all nodes are online and the cluster has had time to settle, verify that ev
     - ***Last State*** -- VM powers on only if it was on at the time of power loss
     - ***Leave Off*** -- VM stays off when power is restored, regardless of prior state
     - ***Power On*** -- VM powers on when power is restored, regardless of prior state
-- **Repair server (ioGuardian)** -- a configured [repair server](/product-guide/backup-dr/repair-server/) gives VergeFS a fallback source for missing blocks if peer nodes can't supply them after an outage. It pulls needed blocks from a synchronized remote VergeOS system and is built from an existing outgoing site sync configuration. Repair servers are trongly recommended for any production deployment.
+- **Repair server (ioGuardian)** -- a configured [repair server](/product-guide/backup-dr/repair-server/) gives VergeFS a fallback source for missing blocks if peer nodes can't supply them after an outage. It pulls needed blocks from a synchronized remote VergeOS system and is built from an existing outgoing site sync configuration. Repair servers are strongly recommended for any production deployment.
 - **Adequate snapshot rotation** -- maintain a snapshot retention schedule that keeps recent, pre-event snapshots available for rollback when needed. Replicating snapshots to a remote site is also recommended as part of a comprehensive data protection strategy.
 
 
 ## When to Engage Support
 
-Open a support case **before** rebooting nodes if any of the following are true:
+Open a support case **before** rebooting nodes, or making any other significant changes, if any of the following are true:
 
 - vSAN won't mount after N nodes are online (e.g. N-1 nodes in a default N+1 redundancy)
 - A tier shows **Redundant: false** for an extended period after Full Walks complete
 - The **Repairs** count is stuck or growing
-- A stuck-repairs alert is present (VergeOS 26+)
+- A stuck-repairs alert is present (VergeOS v26+)
 - Multiple drives report errors after recovery
 - You suspect split-brain or inconsistent cluster state
 - Any node fails to rejoin and the cause isn't obviously hardware
@@ -167,7 +173,7 @@ See [Generating System Diagnostics](/knowledge-base/generating-system-diagnostic
 - [Generating System Diagnostics](/knowledge-base/generating-system-diagnostics/)
 - [Repair Server (ioGuardian)](/product-guide/backup-dr/repair-server/)
 - [vSAN Diagnostics Guide](/product-guide/storage/vsan-diagnostics/)
-- [Sizing & Hardware Requirements](/implementation-guide/sizing/)
+
 
 ## Feedback
 

--- a/docs/knowledge-base/posts/proper-power-sequence.md
+++ b/docs/knowledge-base/posts/proper-power-sequence.md
@@ -30,32 +30,45 @@ dateCreated: 2024-06-24T13:49:31.305Z
 
 ## Proper Shutdown Sequence for a VergeOS Environment
 
-To power off a cluster (a collection of two or more nodes) follow these steps:
+To power off a cluster (a collection of two or more nodes), follow these steps:
 
 1. Check any running workloads on each node of the cluster. Navigate to the node dashboard for each node and review the **Running Machines** section.
 2. If there are tenants running on any of the nodes, log into those tenant environments and gracefully shut down all running workloads.
-3. Power off all running workloads on each node, including VMs, tenant nodes, VMware backup services, and NAS services (if applicable).  
-!!! info "vNet Containers"
-    There is no need to manually stop any running vNet containers; they will be gracefully stopped automatically in the subsequent steps.
+3. Power off all running workloads on each node, including VMs, tenant nodes, VMware backup services, and NAS services (if applicable).
+
+    !!! info "vNet Containers"
+        There is no need to manually stop any running vNet containers; they will be gracefully stopped automatically in the subsequent steps.
 
 4. After stopping all running workloads, navigate to the **Cluster dashboard** for the cluster you wish to power off.
 5. Select **Power Off** from the left-hand menu to begin shutting down each node in the cluster.
-6. Finally, navigate to **System -> Clusters** and select **Power Off** in the left menu to power off the entire cluster.
+6. Finally, navigate to **System → Clusters** and select **Power Off** in the left menu to power off the entire cluster.
+
 !!! warning "IMPORTANT"
     If an environment contains multiple clusters, _**ALWAYS**_ shut down the cluster containing the controller nodes (Node1 & Node2) **LAST**.
 
 ---
 
-## Proper Power On Sequence for a VergeOS Environment
+## Proper Power-On Sequence for a VergeOS Environment
 
 To properly power on a VergeOS environment, perform the following steps:
 
 1. Power on **Node1**.
-1. Once **Node1** is online, power on **Node2**.
-1. Power on all other nodes, waiting approximately 1 minute between power actions.
-1. On the main dashboard, verify that the environment is **Green** and **Online**.
+2. **Wait 30 seconds to a minute.**
+    - This brief pause lets Node1 begin initializing before the rest of the cluster arrives.
+3. **Power on all other nodes within the cluster.** All other cluster nodes can be powered on immediately -- there is no need to delay between nodes.
+4. **Multi-cluster environments:** bring the controller cluster fully online before powering on additional clusters.
+5. The system will automatically perform integrity checks of each storage tier.
 
-![main-dash-stoplights.png](/product-guide/screenshots/main-dash-stoplights.png)
+    !!! tip "Storage Tier Integrity Checks"
+        See [vSAN Tier Status (Journal Walks)](/knowledge-base/understanding-journal-walks-and-vsan-tier-status/) for information related to these automatic integrity checks (journal walks).
+
+6. **Verify system health.**
+    - On the Main Dashboard, verify all nodes and vSAN tiers appear with a green status.
+    - Check for any new alarms.
+
+!!! warning "Power-On After an Uncontrolled Shutdown"
+    Extra care should be taken when powering on a cluster after an uncontrolled shutdown (e.g. an abrupt power loss, UPS exhaustion, or facility failure). See [Cluster Recovery After Full Power Outage](/knowledge-base/cluster-recovery-after-power-outage/) for the full recovery procedure, including pre-power-on checks, vSAN integrity verification, and prevention guidance.
+
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a new KB article addressing #441: a consolidated how-to / troubleshooting guide for recovering a VergeOS cluster after an unplanned full power loss.

## Changes

- New file: `docs/knowledge-base/posts/cluster-recovery-after-power-outage.md`
- Patterned after `kb-template.md` (frontmatter, Key Points, Prerequisites, Steps, Troubleshooting, Prevention, Additional Resources, Feedback, Document Information)
- Cross-links to existing docs: Proper Power Sequence, Proper Shutdown Procedure, Journal Walks, Generating System Diagnostics, Repair Server (ioGuardian), vSAN Diagnostics Guide, System Diagnostics, Sizing & Hardware Requirements

## Issue coverage (per #441 "Suggested Content")

- ✅ Expected cluster behavior after simultaneous full power loss (`What to Expect` subsection)
- ✅ Recommended host power-on sequence — including the verbatim `Waiting for the vSAN to mount` console prompt as the operator's go-signal between Node1 and Node2
- ✅ Rejoin order and how nodes resync vSAN tiers (auto-reconciliation via Journal Walks once quorum is reached)
- ✅ Step-by-step recovery procedure (pre-checks → power-on → verification)
- ✅ How to verify vSAN health and tier sync status post-recovery (Status tile fields, Repairs/Bad Drives interpretation, vSAN Diagnostics CLI equivalents)
- ✅ Recommendations to prevent data inconsistency or corruption — UPS sizing, graceful shutdown automation (UI / API / [VRG CLI](https://github.com/verge-io/vrg)), On Power Loss VM settings, ioGuardian repair server, off-site snapshots, fencing-handled-internally explainer
- ✅ Troubleshooting: node fails to rejoin, vSAN won't mount, stuck/growing repairs, split-brain
- ✅ When to engage VergeIO support, with explicit sysdiag generation steps and `support@verge.io` for the air-gapped/manual path

## Verification

- All UI nav paths verified against existing operational KBs (System → vSAN → Tiers, System → vSAN → Drives, System → Nodes, System → vSAN Diagnostics, System → System Diagnostics)
- API payload `POST /v4/cluster_actions { action: shutdown }` matches the existing Proper Shutdown Procedure doc and API Tables reference
- Cluster reconciliation, Journal Walk, and quorum behavior cross-checked against the Journal Walks KB and stuck-repairs internal doc
- Sysdiag UI label and parent/root requirement cross-checked against both Generating System Diagnostics and System Diagnostics docs
- Version footer aligned with currently supported releases (26.0+)

## Test plan

- [x] Render preview in mkdocs and verify all admonitions, code blocks, and internal links resolve
- [x] Confirm the `Waiting for the vSAN to mount` console string matches what customers see on 26.x (verified against an in-the-wild console screenshot)
- [x] Tech review by support / engineering for any internal-only details that shouldn't be public