### PR TITLE
Add bridge mode warning: untagged external networks incompatible with…

### DIFF
--- a/docs/knowledge-base/posts/tenant-layer2-access.md
+++ b/docs/knowledge-base/posts/tenant-layer2-access.md
@@ -86,6 +86,10 @@ dateCreated: 2025-02-10T19:58:59.133Z
        You can filter the list of networks by "Type" to display only the physical networks.
 3. Select **Edit** to enter the network configuration page.
 4. In the configuration page, enable **Physical Bridged** to activate Bridge Mode. It is best to set the **On Power Loss** setting to ***Power On*** so that the network starts up automatically after a system power loss.
+
+!!! warning "Bridge Mode Requires All Traffic to Be VLAN-Tagged"
+    Enabling Physical Bridge Mode causes the interface to operate as a raw Layer 2 bridge — **all traffic must carry a VLAN tag**. Any external network configured with **VLAN type: None** (untagged/native VLAN) on this same physical interface will **stop passing traffic**. If you need untagged (native VLAN) access on a port, do not enable bridge mode on that physical network.
+
 5. **Submit** your changes.
 6. **Reboot** the necessary nodes for Bridge Mode to become active.
 !!! warning "Follow proper [**Maintenance Mode**](/product-guide/operations/maintenance-mode) procedures when rebooting a node to avoid workload disruptions."

--- a/docs/knowledge-base/posts/tenant-layer2-access.md
+++ b/docs/knowledge-base/posts/tenant-layer2-access.md
@@ -87,8 +87,8 @@ dateCreated: 2025-02-10T19:58:59.133Z
 3. Select **Edit** to enter the network configuration page.
 4. In the configuration page, enable **Physical Bridged** to activate Bridge Mode. It is best to set the **On Power Loss** setting to ***Power On*** so that the network starts up automatically after a system power loss.
 
-!!! warning "Bridge Mode Requires All Traffic to Be VLAN-Tagged"
-    Enabling Physical Bridge Mode causes the interface to operate as a raw Layer 2 bridge — **all traffic must carry a VLAN tag**. Any external network configured with **VLAN type: None** (untagged/native VLAN) on this same physical interface will **stop passing traffic**. If you need untagged (native VLAN) access on a port, do not enable bridge mode on that physical network.
+    !!! warning "Bridge Mode Requires All Traffic to Be VLAN-Tagged"
+        Enabling Physical Bridge Mode causes the interface to operate as a raw Layer 2 bridge — **all traffic must carry a VLAN tag**. Any external network configured with **VLAN type: None** (untagged/native VLAN) on this same physical interface will **stop passing traffic**. If you need untagged (native VLAN) access on a port, do not enable bridge mode on that physical network.
 
 5. **Submit** your changes.
 6. **Reboot** the necessary nodes for Bridge Mode to become active.
@@ -139,3 +139,8 @@ dateCreated: 2025-02-10T19:58:59.133Z
 * Confirm firewall rules related to the Virtual Switch Port have been applied.
 * Verify the destination tenant network and VLAN network are in the "Running" state and reside on the same physical node.
 * Ensure VLANs are trunked to the correct physical node ports.
+
+### Untagged external network is not passing traffic
+
+* Check whether **Physical Bridged** is enabled on the underlying physical network. Bridge mode requires all traffic on the interface to be VLAN-tagged, so any external network with **VLAN type: None** (untagged/native VLAN) on that physical interface will stop passing traffic.
+* If you need untagged (native VLAN) access on the port, disable Physical Bridge Mode on the physical network and reboot the affected nodes (following [**Maintenance Mode**](/product-guide/operations/maintenance-mode) procedures).

--- a/docs/knowledge-base/posts/tenant-layer2-access.md
+++ b/docs/knowledge-base/posts/tenant-layer2-access.md
@@ -87,8 +87,8 @@ dateCreated: 2025-02-10T19:58:59.133Z
 3. Select **Edit** to enter the network configuration page.
 4. In the configuration page, enable **Physical Bridged** to activate Bridge Mode. It is best to set the **On Power Loss** setting to ***Power On*** so that the network starts up automatically after a system power loss.
 
-    !!! warning "Bridge Mode Requires All Traffic to Be VLAN-Tagged"
-        Enabling Physical Bridge Mode causes the interface to operate as a raw Layer 2 bridge — **all traffic must carry a VLAN tag**. Any external network configured with **VLAN type: None** (untagged/native VLAN) on this same physical interface will **stop passing traffic**. If you need untagged (native VLAN) access on a port, do not enable bridge mode on that physical network.
+    !!! note "Bridge Mode and Untagged Networks"
+        Bridge mode has been observed to interfere with untagged (**Layer 2 Type: None**) external networks on the same physical interface. If you need untagged (native VLAN) access on this port, see [Untagged external network is not passing traffic](#untagged-external-network-is-not-passing-traffic).
 
 5. **Submit** your changes.
 6. **Reboot** the necessary nodes for Bridge Mode to become active.
@@ -142,5 +142,5 @@ dateCreated: 2025-02-10T19:58:59.133Z
 
 ### Untagged external network is not passing traffic
 
-* Check whether **Physical Bridged** is enabled on the underlying physical network. Bridge mode requires all traffic on the interface to be VLAN-tagged, so any external network with **VLAN type: None** (untagged/native VLAN) on that physical interface will stop passing traffic.
-* If you need untagged (native VLAN) access on the port, disable Physical Bridge Mode on the physical network and reboot the affected nodes (following [**Maintenance Mode**](/product-guide/operations/maintenance-mode) procedures).
+* Check whether **Physical Bridged** is enabled on the underlying physical network. Bridge mode has been observed to interfere with untagged (**Layer 2 Type: None**) external networks on the same physical interface.
+* If nothing on the interface still requires bridge mode, disable it and reboot the affected nodes (following [**Maintenance Mode**](/product-guide/operations/maintenance-mode) procedures). Consider migrating remaining Virtual Switch Port configurations to [Tenant Layer 2 Networks](/product-guide/tenants/layer-2-networks), which do not require bridge mode.

--- a/docs/product-guide/networks/network-concepts.md
+++ b/docs/product-guide/networks/network-concepts.md
@@ -39,6 +39,9 @@ This guide provides a foundational introduction to VergeOS networking, helping b
 A physical network is a representation of each isolated layer 2 connection. Physical networks are typically all configured during VergeOS install. 
 !!! tip "The system automatically appends "Switch" to the end of the user-supplied name during install, for ex: for name "PXE", the system will give the physical network the name "PXE Switch""
 
+!!! info "Physical Bridge Mode"
+    Physical networks have a **Physical Bridged** toggle that puts the NIC into raw Layer 2 bridge mode, enabling tagged VLAN trunk passthrough for use cases like [Virtual Switch Ports](/knowledge-base/provide-layer2-to-tenant) and [Tenant Layer 2 Networks](/product-guide/tenants/layer-2-networks). **When bridge mode is enabled, all traffic on that interface must be VLAN-tagged.** External networks with VLAN type **None** (untagged/native VLAN) will not pass traffic on a bridged physical interface. Bridge mode requires a node reboot to take effect.
+
 ### Core Network
 
 A virtual network, created automatically during the VergeOS installation/tenant creation, to handle all vSAN and internode communication. Core traffic is run across multiple (typically two) physical networks to provide redundancy.

--- a/docs/product-guide/networks/network-concepts.md
+++ b/docs/product-guide/networks/network-concepts.md
@@ -40,7 +40,7 @@ A physical network is a representation of each isolated layer 2 connection. Phys
 !!! tip "The system automatically appends "Switch" to the end of the user-supplied name during install, for ex: for name "PXE", the system will give the physical network the name "PXE Switch""
 
 !!! info "Physical Bridge Mode"
-    Physical networks have a **Physical Bridged** toggle that puts the NIC into raw Layer 2 bridge mode, enabling tagged VLAN trunk passthrough for use cases like [Virtual Switch Ports](/knowledge-base/provide-layer2-to-tenant) and [Tenant Layer 2 Networks](/product-guide/tenants/layer-2-networks). **When bridge mode is enabled, all traffic on that interface must be VLAN-tagged.** External networks with VLAN type **None** (untagged/native VLAN) will not pass traffic on a bridged physical interface. Bridge mode requires a node reboot to take effect.
+    Physical networks have a **Physical Bridged** toggle that puts the NIC into raw Layer 2 bridge mode. This setting exists to support legacy trunk-mode [Virtual Switch Port](/knowledge-base/provide-layer2-to-tenant) configurations. For passing VLANs to tenants, we recommend [Tenant Layer 2 Networks](/product-guide/tenants/layer-2-networks) instead, which do not require bridge mode. Leave bridge mode disabled unless existing Virtual Switch Ports depend on it — it has been observed to interfere with untagged (**Layer 2 Type: None**) external networks on the same interface. Changing this setting requires a node reboot.
 
 ### Core Network
 


### PR DESCRIPTION
… Physical Bridge Mode

When Physical Bridge Mode is enabled on a physical network, all traffic must be VLAN-tagged. External networks with VLAN type None (untagged/native) will not pass traffic on a bridged interface. Adds a warning callout to the trunk mode Virtual Switch Port setup section and a bridge mode info note to the Networking Concepts physical network definition.

Closes #461