### PR TITLE
docs(kb): SonicWall NSv 7.1.1+ will not boot on VergeOS

### DIFF
--- a/docs/knowledge-base/posts/sonicwall-nsv-boot-failure-signed-firmware.md
+++ b/docs/knowledge-base/posts/sonicwall-nsv-boot-failure-signed-firmware.md
@@ -1,0 +1,74 @@
+---
+title: SonicWall NSv 7.1.1+ Will Not Boot on VergeOS
+slug: sonicwall-nsv-boot-failure-signed-firmware
+description: SonicWall NSv virtual firewalls running SonicOS 7.1.1 and later fail to boot after import into VergeOS because the appliance requires SonicWall's own signed OVMF firmware. Here is why it happens and what to run instead.
+author: VergeOS Documentation Team
+draft: false
+date: 2026-07-09T00:00:00.000Z
+semantic_keywords:
+  - "sonicwall nsv virtual firewall won't boot vergeos"
+  - "sonicwall nsv invalid firmware detected import"
+  - "sonicos 7.1.1 signed ovmf secure boot firmware"
+  - "import sonicwall nsv kvm qcow2 ova vhdx fails"
+  - "custom efi firmware nvram vergeos not supported"
+use_cases:
+  - import_sonicwall_nsv_into_vergeos
+  - run_virtual_firewall_on_vergeos
+  - troubleshoot_vm_boot_failure_after_import
+tags:
+  - vm
+  - import
+  - migration
+  - firewall
+  - sonicwall
+  - nsv
+  - secure boot
+  - ovmf
+  - uefi
+  - efi
+  - firmware
+  - won't boot
+  - not booting
+  - invalid firmware
+  - troubleshooting
+categories:
+  - Troubleshooting
+  - Migration
+editor: markdown
+dateCreated: 2026-07-09T00:00:00.000Z
+---
+
+# SonicWall NSv 7.1.1+ Will Not Boot on VergeOS
+
+SonicWall NSv virtual firewalls running SonicOS 7.1.1 and later cannot be imported and booted on VergeOS. This guide explains why the appliance fails to start and what we recommend running in its place.
+
+## Symptoms
+
+- You import a SonicWall NSv appliance into VergeOS and it fails to boot.
+- The console shows a firmware validation error such as `Invalid firmware detected`.
+- The failure is the same no matter which source format you import from — KVM/QCOW2, VMware OVA, or Hyper-V VHDX.
+
+## Overview
+
+SonicWall ships the NSv image with its own custom OVMF firmware files — `OVMF_CODE.sw.fd` and `OVMF_VARS.sw.fd` — that carry SonicWall-specific Secure Boot certificates. At boot, SonicCoreX checks that it is running on exactly that firmware and aborts on anything else.
+
+VergeOS builds and manages each VM's UEFI variable disk itself, from standard OVMF templates, and does not allow the EFI disk's media source to be swapped through the UI or API. Because there is no supported way to present SonicWall's custom firmware files to the VM, the appliance's boot-time firmware check fails and the NSv never comes up.
+
+!!! info "Why every import format fails the same way"
+    The block is in the appliance's firmware validation, not in any one disk format. Converting or re-importing the image — QCOW2, OVA, or VHDX — does not change the outcome, because none of those paths let you supply SonicWall's signed `.fd` firmware.
+
+!!! note "Applies to SonicOS 7.1.1 and later"
+    Earlier SonicOS builds that did not enforce the signed-firmware check are not affected in the same way. The behavior described here is specific to NSv on 7.1.1+.
+
+## What to run instead
+
+For a virtual firewall on VergeOS, we recommend **pfSense** or **OPNsense**. Both boot cleanly on VergeOS's standard UEFI firmware and are well suited to running as a VM or inside a tenant.
+
+If you are set on SonicWall specifically, run it on physical SonicWall hardware and connect it to your VergeOS environment over the network, rather than trying to virtualize the NSv appliance.
+
+## Additional Resources
+
+- [Best Practices - Running a pfSense Virtual Firewall](/knowledge-base/running-a-pfsense-virtual-firewall)
+
+!!! question "Need Help?"
+    If you are planning a firewall migration into VergeOS and want to talk through options, contact VergeOS support.

--- a/docs/knowledge-base/posts/sonicwall-nsv-boot-failure-signed-firmware.md
+++ b/docs/knowledge-base/posts/sonicwall-nsv-boot-failure-signed-firmware.md
@@ -65,13 +65,9 @@ VergeOS builds and manages each VM's UEFI variable disk itself, from standard OV
 
 ## Options in the meantime
 
-Any virtual firewall that boots on standard UEFI firmware — for example, pfSense or OPNsense — runs well on VergeOS, either as a VM or inside a tenant, and can fill the role until NSv support arrives.
+Any virtual firewall that boots on standard UEFI firmware runs well on VergeOS, either as a VM or inside a tenant, and can fill the role until NSv support arrives.
 
 If you want to stay on SonicWall today, run the firewall on physical SonicWall hardware and connect it to your VergeOS environment over the network, rather than trying to virtualize the NSv appliance.
-
-## Additional Resources
-
-- [Best Practices - Running a pfSense Virtual Firewall](/knowledge-base/running-a-pfsense-virtual-firewall)
 
 !!! question "Need Help?"
     If you are planning a firewall migration into VergeOS and want to talk through options, contact VergeOS support.

--- a/docs/knowledge-base/posts/sonicwall-nsv-boot-failure-signed-firmware.md
+++ b/docs/knowledge-base/posts/sonicwall-nsv-boot-failure-signed-firmware.md
@@ -42,6 +42,9 @@ dateCreated: 2026-07-09T00:00:00.000Z
 
 SonicWall NSv virtual firewalls running SonicOS 7.1.1 and later cannot be imported and booted on VergeOS. This guide explains why the appliance fails to start and what we recommend running in its place.
 
+!!! info "Support coming in Q3 2026"
+    We are adding support for custom EFI firmware in Q3 2026, which will allow the SonicWall NSv appliance to boot on VergeOS. Until that support ships, use one of the alternatives described below.
+
 ## Symptoms
 
 - You import a SonicWall NSv appliance into VergeOS and it fails to boot.

--- a/docs/knowledge-base/posts/sonicwall-nsv-boot-failure-signed-firmware.md
+++ b/docs/knowledge-base/posts/sonicwall-nsv-boot-failure-signed-firmware.md
@@ -1,7 +1,7 @@
 ---
 title: SonicWall NSv 7.1.1+ Will Not Boot on VergeOS
 slug: sonicwall-nsv-boot-failure-signed-firmware
-description: SonicWall NSv virtual firewalls running SonicOS 7.1.1 and later fail to boot after import into VergeOS because the appliance requires SonicWall's own signed OVMF firmware. Here is why it happens and what to run instead.
+description: SonicWall NSv virtual firewalls running SonicOS 7.1.1 and later fail to boot after import into VergeOS because the appliance requires SonicWall's own signed OVMF firmware. Support for custom EFI firmware is coming in Q3 2026; here is why the boot fails and what your options are in the meantime.
 author: VergeOS Documentation Team
 draft: false
 date: 2026-07-09T00:00:00.000Z
@@ -40,7 +40,7 @@ dateCreated: 2026-07-09T00:00:00.000Z
 
 # SonicWall NSv 7.1.1+ Will Not Boot on VergeOS
 
-SonicWall NSv virtual firewalls running SonicOS 7.1.1 and later cannot be imported and booted on VergeOS. This guide explains why the appliance fails to start and what we recommend running in its place.
+SonicWall NSv virtual firewalls running SonicOS 7.1.1 and later cannot currently be imported and booted on VergeOS. This guide explains why the appliance fails to start and what your options are in the meantime.
 
 !!! info "Support coming in Q3 2026"
     We are adding support for custom EFI firmware in Q3 2026, which will allow the SonicWall NSv appliance to boot on VergeOS. Until that support ships, use one of the alternatives described below.
@@ -55,7 +55,7 @@ SonicWall NSv virtual firewalls running SonicOS 7.1.1 and later cannot be import
 
 SonicWall ships the NSv image with its own custom OVMF firmware files — `OVMF_CODE.sw.fd` and `OVMF_VARS.sw.fd` — that carry SonicWall-specific Secure Boot certificates. At boot, SonicCoreX checks that it is running on exactly that firmware and aborts on anything else.
 
-VergeOS builds and manages each VM's UEFI variable disk itself, from standard OVMF templates, and does not allow the EFI disk's media source to be swapped through the UI or API. Because there is no supported way to present SonicWall's custom firmware files to the VM, the appliance's boot-time firmware check fails and the NSv never comes up.
+VergeOS builds and manages each VM's UEFI variable disk itself, from standard OVMF templates, and does not currently allow the EFI disk's media source to be swapped through the UI or API. Because there is no supported way to present SonicWall's custom firmware files to the VM, the appliance's boot-time firmware check fails and the NSv never comes up.
 
 !!! info "Why every import format fails the same way"
     The block is in the appliance's firmware validation, not in any one disk format. Converting or re-importing the image — QCOW2, OVA, or VHDX — does not change the outcome, because none of those paths let you supply SonicWall's signed `.fd` firmware.
@@ -63,11 +63,11 @@ VergeOS builds and manages each VM's UEFI variable disk itself, from standard OV
 !!! note "Applies to SonicOS 7.1.1 and later"
     Earlier SonicOS builds that did not enforce the signed-firmware check are not affected in the same way. The behavior described here is specific to NSv on 7.1.1+.
 
-## What to run instead
+## Options in the meantime
 
-For a virtual firewall on VergeOS, we recommend **pfSense** or **OPNsense**. Both boot cleanly on VergeOS's standard UEFI firmware and are well suited to running as a VM or inside a tenant.
+Any virtual firewall that boots on standard UEFI firmware — for example, pfSense or OPNsense — runs well on VergeOS, either as a VM or inside a tenant, and can fill the role until NSv support arrives.
 
-If you are set on SonicWall specifically, run it on physical SonicWall hardware and connect it to your VergeOS environment over the network, rather than trying to virtualize the NSv appliance.
+If you want to stay on SonicWall today, run the firewall on physical SonicWall hardware and connect it to your VergeOS environment over the network, rather than trying to virtualize the NSv appliance.
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary

New KB article documenting why **SonicWall NSv** virtual firewalls on SonicOS 7.1.1+ fail to boot after import into VergeOS, and what to run instead.

**Root cause:** the NSv appliance requires SonicWall's own signed OVMF firmware (`OVMF_CODE.sw.fd` / `OVMF_VARS.sw.fd` with SonicWall Secure Boot certs). VergeOS builds/manages the VM's UEFI variable disk from standard OVMF templates and doesn't allow swapping the EFI disk's media source, so the appliance's boot-time firmware check fails on every import format (QCOW2, OVA, VHDX). Recommends pfSense/OPNsense as supported alternatives.

## Type
Troubleshooting

## Source
Recurring support pattern — three separate customer cases hit this. Promoted from internal support KB.

## Checks
- `validate_frontmatter.py` passes locally (all required KB fields present)
- Only internal link points at an existing KB slug (`running-a-pfsense-virtual-firewall`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)