### PR TITLE
docs(kb): per-VM tenant DR recovery follows snapshot ownership

### DIFF
--- a/docs/knowledge-base/posts/per-vm-dr-tenant-to-tenant-sync.md
+++ b/docs/knowledge-base/posts/per-vm-dr-tenant-to-tenant-sync.md
@@ -1,0 +1,66 @@
+---
+title: Recovering a Single VM in DR Requires a Tenant-to-Tenant Sync
+slug: per-vm-dr-tenant-to-tenant-sync
+description: A provider-to-provider sync replicates your whole system into DR and gives you no clean handle to restore one VM. For per-VM DR recovery, use a tenant-to-tenant sync instead.
+author: VergeOS Documentation Team
+draft: false
+date: 2026-07-09T00:00:00.000Z
+semantic_keywords:
+  - "recover single vm disaster recovery vergeos"
+  - "provider-to-provider sync vs tenant-to-tenant sync per vm dr"
+  - "restore one vm from dr site granularity"
+  - "test dr recovery individual virtual machine"
+  - "site sync direction provider tenant replication topology"
+use_cases:
+  - test_dr_recovery_of_a_single_vm
+  - choose_dr_sync_direction
+  - recover_individual_vm_at_dr_site
+tags:
+  - dr
+  - disaster recovery
+  - sync
+  - site sync
+  - tenant
+  - tenant-to-tenant
+  - provider-to-provider
+  - replication
+  - snapshot
+  - recovery
+  - backup
+categories:
+  - Backup and DR
+  - Tenant
+  - Best Practices
+editor: markdown
+dateCreated: 2026-07-09T00:00:00.000Z
+---
+
+# Recovering a Single VM in DR Requires a Tenant-to-Tenant Sync
+
+If you want to test DR recovery of one virtual machine, the sync direction you choose matters. A common assumption is that a provider-to-provider sync between production and DR gives you per-VM granularity. It doesn't — and this guide explains why, and what to set up instead.
+
+## The problem
+
+A provider-to-provider sync replicates your **entire** production system into the DR provider. The object that lands on the DR side is the production *system*, not the individual VMs inside it. There is no clean handle to "restore one VM" out of a provider-to-provider sync, so if your goal is per-VM DR testing, this topology fights you.
+
+## The fix: sync at the tenant level
+
+Replace the provider-to-provider sync with a **tenant-to-tenant sync** — production tenant to DR tenant. Once that sync is flowing:
+
+1. Hop into the DR tenant.
+2. Find the synced VM's snapshots.
+3. Recover the target VM in isolation. The rest of the tenant is untouched.
+
+!!! warning "Don't run both syncs at once"
+    Keeping the provider-to-provider sync running alongside the tenant-to-tenant sync replicates production twice — double the overhead, with no DR benefit. The tenant-to-tenant sync supersedes the provider-to-provider one for this use case, so retire the provider-to-provider sync once the tenant sync is established.
+
+!!! info "Pick the sync direction that matches your goal"
+    VergeOS syncs run in three directions: **provider-to-provider**, **provider-to-tenant**, and **tenant-to-tenant**. Provider-to-provider mirrors an entire system; tenant-to-tenant mirrors a single tenant and lets you recover its VMs individually. When you need per-VM recovery, reach for tenant-to-tenant.
+
+## Additional Resources
+
+- [Configuring a Site Sync](/product-guide/backup-dr/sync-configuration/)
+- [VM Snapshots and Restores](/product-guide/backup-dr/vm-snapshots-restores/)
+
+!!! question "Need Help?"
+    If you're designing a DR topology and aren't sure which sync direction fits, contact VergeOS support before you start replicating.

--- a/docs/knowledge-base/posts/per-vm-dr-tenant-to-tenant-sync.md
+++ b/docs/knowledge-base/posts/per-vm-dr-tenant-to-tenant-sync.md
@@ -1,32 +1,31 @@
 ---
-title: Recovering a Single VM in DR Requires a Tenant-to-Tenant Sync
-slug: per-vm-dr-tenant-to-tenant-sync
-description: A provider-to-provider sync replicates your whole system into DR and gives you no clean handle to restore one VM. For per-VM DR recovery, use a tenant-to-tenant sync instead.
+title: Recovering a Single VM from Inside a Tenant at Your DR Site
+slug: per-vm-dr-recovery-tenant-level-sync
+description: A host-level site sync replicates a tenant as one object, so there is no single VM to pull out of it at the DR site. Sync at the tenant level when you need per-VM recovery, especially when the DR system is smaller than production.
 author: VergeOS Documentation Team
 draft: false
-date: 2026-07-09T00:00:00.000Z
+date: 2026-07-31T00:00:00.000Z
 semantic_keywords:
-  - "recover single vm disaster recovery vergeos"
-  - "provider-to-provider sync vs tenant-to-tenant sync per vm dr"
-  - "restore one vm from dr site granularity"
-  - "test dr recovery individual virtual machine"
-  - "site sync direction provider tenant replication topology"
+  - "recover one VM from a tenant at the DR site"
+  - "site sync host level or tenant level which to choose"
+  - "tenant will not power on at DR site not enough RAM"
+  - "restore single virtual machine from replicated tenant snapshot"
+  - "test DR recovery of an individual VM inside a tenant"
 use_cases:
+  - recover_individual_vm_inside_tenant_at_dr
+  - choose_site_sync_level
   - test_dr_recovery_of_a_single_vm
-  - choose_dr_sync_direction
-  - recover_individual_vm_at_dr_site
+  - plan_dr_site_sizing_for_tenants
 tags:
   - dr
   - disaster recovery
-  - sync
   - site sync
+  - sync
   - tenant
-  - tenant-to-tenant
-  - provider-to-provider
-  - replication
   - snapshot
   - recovery
   - backup
+  - sizing
 categories:
   - Backup and DR
   - Tenant
@@ -35,32 +34,78 @@ editor: markdown
 dateCreated: 2026-07-09T00:00:00.000Z
 ---
 
-# Recovering a Single VM in DR Requires a Tenant-to-Tenant Sync
+# Recovering a Single VM from Inside a Tenant at Your DR Site
 
-If you want to test DR recovery of one virtual machine, the sync direction you choose matters. A common assumption is that a provider-to-provider sync between production and DR gives you per-VM granularity. It doesn't — and this guide explains why, and what to set up instead.
+If the VM you need back lives inside a tenant, the level you configured your site sync at decides how hard the recovery is. A host-level sync replicates the tenant as a single object, so there is no individual VM to pick out of it on the DR side. Syncing at the tenant level puts the snapshots where per-VM recovery already works.
 
-## The problem
+## Recovery granularity follows the system that owns the snapshot
 
-A provider-to-provider sync replicates your **entire** production system into the DR provider. The object that lands on the DR side is the production *system*, not the individual VMs inside it. There is no clean handle to "restore one VM" out of a provider-to-provider sync, so if your goal is per-VM DR testing, this topology fights you.
+Site syncs replicate [system snapshots](/product-guide/backup-dr/system-snapshots). When you select a received snapshot on the destination system, you get two listings:
 
-## The fix: sync at the tenant level
+- **View VMs** lists the VMs belonging to the host that took the snapshot.
+- **View Tenants** lists the tenants that existed on that host.
 
-Replace the provider-to-provider sync with a **tenant-to-tenant sync** — production tenant to DR tenant. Once that sync is flowing:
+There is no third listing for the VMs inside those tenants. A host-level snapshot will not show them at all. You have to restore the tenant to get that list, and restoring the tenant is also what makes those VMs recoverable. Both the listing and the restore come from the tenant reading its own snapshots. From the host's snapshot, the smallest thing you can pull out of a tenant is the tenant.
 
-1. Hop into the DR tenant.
-2. Find the synced VM's snapshots.
-3. Recover the target VM in isolation. The rest of the tenant is untouched.
+That gives you the rule to plan around: you can recover one level down from the system that owns the snapshot, and no further. A host's snapshot gets you the host's VMs and its whole tenants. A tenant's snapshot gets you that tenant's VMs.
 
-!!! warning "Don't run both syncs at once"
-    Keeping the provider-to-provider sync running alongside the tenant-to-tenant sync replicates production twice — double the overhead, with no DR benefit. The tenant-to-tenant sync supersedes the provider-to-provider one for this use case, so retire the provider-to-provider sync once the tenant sync is established.
+## Recovering a tenant's VM through a host-level sync
 
-!!! info "Pick the sync direction that matches your goal"
-    VergeOS syncs run in three directions: **provider-to-provider**, **provider-to-tenant**, and **tenant-to-tenant**. Provider-to-provider mirrors an entire system; tenant-to-tenant mirrors a single tenant and lets you recover its VMs individually. When you need per-VM recovery, reach for tenant-to-tenant.
+DR systems are usually sized well below production. Take a common pair:
+
+|              | Production                        | DR                       |
+| ------------ | --------------------------------- | ------------------------ |
+| Host RAM     | 500 GB                            | 128 GB                   |
+| What it runs | One tenant provisioned 200 GB RAM | VergeOS plus a VM or two |
+
+With a host-level sync between these two, recovering one VM out of that tenant means materializing the whole tenant first:
+
+1. On the DR system, select the received snapshot, click **View Tenants**, and click **Recover**. The tenant is restored as a new instance and settles into an *Offline* state.
+2. Power the tenant on. This is where it stops. The recovered tenant carries production's resource allocation, so its nodes want 200 GB of RAM on a 128 GB host. VergeOS will let you assign a tenant node more RAM than the system has, but [the resources have to actually be available to power it on](/product-guide/tenants/add-tenant-resources#add-a-tenant-node).
+
+You can work around it. Tenant node resources can be [reduced on the fly](/product-guide/tenants/reduce-tenant-resources), and you are only opening the tenant to restore the VM, not to run it, so the trim can go well below production. Cut the recovered tenant's nodes down to what it takes to boot the tenant's own VergeOS instance, power the tenant on, log in, and recover the VM from the tenant's snapshot listing. That path does work. What it involves:
+
+- A multi-node tenant has to be edited node by node, and the cluster's *Max RAM per machine* setting caps what any single node can hold.
+- Restoring the VM inside the tenant does not get it out of the tenant. Handing it up to the DR host is another pass with [Shared Objects](/product-guide/tenants/share-vm-snapshot), and returning it to production is a sync back on top of that.
+- If the goal is to *run* the VM at DR rather than extract it, the trimmed tenant has to carry the VM too, and you are back to sizing the DR host for production's workload.
+
+## Sync at the tenant level instead
+
+Run the sync from the production tenant to a tenant on the DR system. The snapshots then arrive inside the DR tenant, which owns them, so its VMs are enumerable and recoverable one at a time.
+
+1. On the DR system, create the tenant that will receive the sync. Size it for the recovery you intend, not for production. Enough for VergeOS plus the VM or two you would bring up is the whole point.
+2. Log into the DR tenant and create the **Incoming Sync**. Log into the production tenant and create the matching **Outgoing Sync**. Both sides are covered in [Configuring a Site Sync](/product-guide/backup-dr/sync-configuration); the sending and receiving system can each be a host or a tenant.
+3. To recover a VM, log into the DR tenant, select the received snapshot, click **View VMs**, select the VM, and click **Recover**. Only that VM's resources have to fit. Full steps, including getting the VM back to production afterward, are in [Recovering a Single VM from a Remote System Snapshot](/knowledge-base/recovering-a-single-vm-from-a-remote-cloud-snapshot).
+
+!!! note "Sync network rules belong to the hosts"
+    The PAT rules that translate incoming sync traffic to the vSAN are created at the host level, not inside a tenant. Work through the [Network Configuration](/product-guide/backup-dr/sync-configuration#network-configuration) section before you build either sync.
+
+!!! warning "A tenant-level sync protects what is inside the tenant"
+    The tenant's resource allocation is provider-side configuration: node count and sizing, provisioned storage, assigned external IP addresses. That lives in the host's records, not in the tenant's own snapshots. Keep a host-level sync, or a written record of the allocation, so you can rebuild the shell that the recovered VMs run in.
+
+## Choosing the level
+
+| What you need to recover                            | Sync at                                               |
+| --------------------------------------------------- | ----------------------------------------------------- |
+| A VM that lives inside a tenant                     | Tenant level                                          |
+| A host-level VM                                     | Host level                                            |
+| A whole tenant, running at DR                       | Host level, with a DR system sized to run that tenant |
+| The entire system: networks, settings, every tenant | Host level                                            |
+
+These are not exclusive. A host-level sync for whole-system protection and a tenant-level sync for per-VM recovery can run side by side.
+
+Pushing the same tenant's data through both costs transfer time rather than capacity. Deduplication on the receiving system collapses the duplicate blocks, so the second copy does not consume the space twice. Both streams still send that data across the link, and both take the time to do it.
+
+On 26.1 and later, [partial system snapshots](/product-guide/backup-dr/system-snapshots) trim the redundant transfer. Keep taking full system snapshots locally for host-level recovery, and send partial snapshots that exclude the tenant offsite. The tenant's offsite protection then rests entirely on its own sync, so monitor that sync accordingly.
 
 ## Additional Resources
 
-- [Configuring a Site Sync](/product-guide/backup-dr/sync-configuration/)
-- [VM Snapshots and Restores](/product-guide/backup-dr/vm-snapshots-restores/)
+- [Configuring a Site Sync](/product-guide/backup-dr/sync-configuration)
+- [Restores from System Snapshots](/product-guide/backup-dr/system-snapshot-restores)
+- [Tenant Restores](/product-guide/tenants/tenant-restores)
+- [Increasing a Tenant's Resources](/product-guide/tenants/add-tenant-resources)
+- [Share a VM Snapshot between Provider and Tenant](/product-guide/tenants/share-vm-snapshot)
+- [Recovering a Single VM from a Remote System Snapshot](/knowledge-base/recovering-a-single-vm-from-a-remote-cloud-snapshot)
 
 !!! question "Need Help?"
-    If you're designing a DR topology and aren't sure which sync direction fits, contact VergeOS support before you start replicating.
+    Designing a DR topology and unsure which level to sync at? Contact VergeOS support before you start replicating. Changing the level later means re-seeding the data.


### PR DESCRIPTION
## Summary

Reworks the KB article on per-VM DR recovery for tenant workloads. The original version asserted that a "provider-to-provider" sync gives "no clean handle" to restore one VM without saying why, and it introduced a three-direction sync taxonomy that appears nowhere in the docs.

The argument is now the actual mechanism. A system snapshot exposes two enumerations, **View VMs** (the host's own VMs) and **View Tenants**, and nothing below that. Reaching a VM nested inside a tenant means restoring the tenant first, because the tenant reading its own snapshots is what produces both the VM listing and the ability to restore it. That generalizes into the rule the article leads with: you recover one level down from the system that owns the snapshot, and no further.

## What changed

- **Terminology matches the docs.** `sync-configuration.md` already describes configuring a Site Sync "at HOST level or at tenant level," so the article uses host level / tenant level with Incoming Sync and Outgoing Sync. The invented provider-to-provider / provider-to-tenant / tenant-to-tenant taxonomy is gone, which resolves the terminology question raised in the original reviewer note.
- **Added the sizing case that motivates the article.** Production at 500 GB RAM hosting a tenant provisioned 200 GB, DR at 128 GB. The tenant recovers fine on the DR side and lands *Offline*, then will not power on, because assigned tenant-node RAM has to actually be available (`add-tenant-resources.md`).
- **The workaround is walked honestly rather than dismissed.** Tenant node RAM can be reduced on the fly, and you are only opening the tenant to restore the VM, not to run it, so the trim can go well below production. The article states what that path involves and lets the reader judge it.
- **Dropped the advice to retire the host-level sync.** That sync is what protects networking, system settings, and the other tenants. Deduplication on the receiving system means replicating one tenant through both paths costs transfer time rather than capacity, so the article points at 26.1 partial system snapshots to trim the redundant transfer instead.
- **Cross-links the existing article** *Recovering a Single VM from a Remote System Snapshot*, which already documents this recovery flow with a destination tenant, instead of duplicating its steps.
- **New caveat.** A tenant-level sync does not carry the tenant's provider-side allocation: node count and sizing, provisioned storage, assigned external IP addresses.

Retitled to *Recovering a Single VM from Inside a Tenant at Your DR Site* and re-slugged to `per-vm-dr-recovery-tenant-level-sync`.

## Type

Conceptual / DR topology decision guide

## Source

Recurring support pattern across two customer cases. Technical claims checked against `system-snapshot-restores.md`, `tenant-restores.md`, `tenant-snapshots.md`, `add-tenant-resources.md`, `reduce-tenant-resources.md`, `share-vm-snapshot.md`, and `sync-configuration.md`, and confirmed with Support.

## Checks

- `validate_frontmatter.py` and `validate_widget_links.py` pass locally
- All eight internal link targets and both section anchors resolve to existing pages that are present in `mkdocs.yml` nav
- `mkdocs build` was not run locally (mkdocs is not installed in this environment), so the lychee link job is unverified on my side

🤖 Generated with [Claude Code](https://claude.com/claude-code)
