### PR TITLE
docs: mark 4.11 release notes status as deprecated

### DIFF
--- a/docs/release-notes/4-11-release-notes.md
+++ b/docs/release-notes/4-11-release-notes.md
@@ -33,8 +33,8 @@ status: deprecated
 !!! info "Series Information"
     - **Initial Release**: February 2023 (4.11.0 Atria)
     - **Latest Version**: 4.11.4.3 (January 2024)
-    - **Status**: Supported (Superseded by 4.12)
-    - **End-of-Life**: TBD
+    - **Status**: Deprecated (Superseded by 4.12)
+    - **End-of-Life**: December 2024
 
 ## Major Features & Themes
 


### PR DESCRIPTION
## Summary
- Updates the 4.11 release notes Series Information block from "Supported (Superseded by 4.12)" / EOL "TBD" to "Deprecated (Superseded by 4.12)" / EOL "December 2024"
- The frontmatter (`status: deprecated`, `deprecated` tag) and the release notes overview table already reflected this — only the visible info block was stale

## Changes
**docs/release-notes/4-11-release-notes.md**
- Status: Deprecated (Superseded by 4.12), matching the wording pattern used on the 4.9 and 4.10 pages
- End-of-Life: December 2024, matching the overview table

## Test Plan
- [ ] Page renders correctly in the MkDocs preview
- [ ] CI frontmatter and link checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)