### PR TITLE
📝 docs: convert absolute image paths to relative paths

### DIFF
--- a/docs/implementation-guide/network-design.md
+++ b/docs/implementation-guide/network-design.md
@@ -98,7 +98,7 @@ This model uses a bonded Layer 2 network for the External, UI and API Management
 
 ### Diagram
 
-![Layer 2 Bonded + Dedicated Core](/assets/layer2bonded-dc.png)
+![Layer 2 Bonded + Dedicated Core](../assets/layer2bonded-dc.png)
 
 ## Layer 3 Dynamic + Dedicated Core Fabric
 
@@ -132,7 +132,7 @@ This model uses dynamically advertised Layer 3 networks for the External, UI and
 
 ### Diagram
 
-![Layer 3 Bonded + Dedicated Core](/assets/layer3dynamic.png)
+![Layer 3 Bonded + Dedicated Core](../assets/layer3dynamic.png)
 
 ## Layer 3 Static + Dedicated Core Fabric
 
@@ -166,7 +166,7 @@ This model uses a bonded Layer 3 network for the External, UI and API Management
 
 ### Diagram
 
-![Layer 3 Bonded + Dedicated Core](/assets/layer3bonded-dc.png)
+![Layer 3 Bonded + Dedicated Core](../assets/layer3bonded-dc.png)
 
 ## Layer 2 Static using 2 network ports
 
@@ -201,6 +201,6 @@ In this model, all networks (Core Fabric, External/Management, Workloads) are co
 
 ### Diagram - 2 network ports
 
-![Layer 2 Bonded](/assets/2nic.png)
+![Layer 2 Bonded](../assets/2nic.png)
 
 By choosing the appropriate network design model based on your specific use case and requirements, you can ensure optimal performance and scalability for your VergeOS deployment.

--- a/docs/knowledge-base/posts/AllowRootToTenantSite.md
+++ b/docs/knowledge-base/posts/AllowRootToTenantSite.md
@@ -66,7 +66,7 @@ This guide provides instructions on how to connect a root system to a tenant sit
      - **Destination**: Any/None.
      - **Target**: My Router IP.
 
-   ![Rule Configuration](/product-guide/screenshots/allow-tenant-root-rule.png)
+   ![Rule Configuration](../../product-guide/screenshots/allow-tenant-root-rule.png)
 
 3. **Submit and Apply**
    - Click **Submit**.

--- a/docs/knowledge-base/posts/access-ui-from-internal.md
+++ b/docs/knowledge-base/posts/access-ui-from-internal.md
@@ -55,7 +55,7 @@ This article guides you through the process of setting up access to the vergeOS 
    - Locate the option to create a new rule
    - Use the settings shown in the image below:
    
-   ![ui-access-rule.png](/product-guide/screenshots/ui-access-rule.png)
+   ![ui-access-rule.png](../../product-guide/screenshots/ui-access-rule.png)
 
 3. Submit the Rule
    - After configuring the rule, submit it

--- a/docs/knowledge-base/posts/accessing-ui-from-a-vm.md
+++ b/docs/knowledge-base/posts/accessing-ui-from-a-vm.md
@@ -95,7 +95,7 @@ This article guides you through the process of setting up access to the VergeOS 
 
 Here's a visual representation of the rule configuration:
 
-![hairpin.png](/product-guide/screenshots/hairpin.png)
+![hairpin.png](../../product-guide/screenshots/hairpin.png)
 
 ## Troubleshooting
 

--- a/docs/knowledge-base/posts/api-guide.md
+++ b/docs/knowledge-base/posts/api-guide.md
@@ -51,7 +51,7 @@ To access the Swagger documentation in the VergeOS UI:
 3. Select **API Documentation**.
 4. The Swagger documentation page will open. This page provides detailed examples for each API operation, including the ability to test the API directly.
    
-   ![Swagger Documentation Example](/product-guide/screenshots/api1.png)
+   ![Swagger Documentation Example](../../product-guide/screenshots/api1.png)
    
 5. Select an individual table and choose one of the available **GET/POST/DELETE/PUT** options to view and test API actions.
 

--- a/docs/knowledge-base/posts/api-helper-script.md
+++ b/docs/knowledge-base/posts/api-helper-script.md
@@ -50,7 +50,7 @@ yb-api --help
 
 Connect to the node and execute this command to begin using the API helper.
 
-![yb-api Example](/product-guide/screenshots/api-helper.png)
+![yb-api Example](../../product-guide/screenshots/api-helper.png)
 
 ## Example Commands
 

--- a/docs/knowledge-base/posts/automated-task-example-webhook.md
+++ b/docs/knowledge-base/posts/automated-task-example-webhook.md
@@ -49,8 +49,8 @@ Using VergeOS Task Engine components, administrators can instantly trigger alert
 
      ***System > Tasks Dashboard > New Webhook***
 
-    ![Create webhook - Light Mode](/product-guide/screenshots/webhook-slack-light.png#only-light)
-    ![Create webhook - Dark Mode](/product-guide/screenshots/webhook-slack-dark.png#only-dark) 
+    ![Create webhook - Light Mode](../../product-guide/screenshots/webhook-slack-light.png#only-light)
+    ![Create webhook - Dark Mode](../../product-guide/screenshots/webhook-slack-dark.png#only-dark) 
 
 
 ??? step-detail "2. Create a Task to Send the Email"
@@ -59,8 +59,8 @@ Using VergeOS Task Engine components, administrators can instantly trigger alert
 
     ***System > Tasks Dashboard > New Task***
 
-    ![Create webhook - Light Mode](/product-guide/screenshots/task-email-light.png#only-light)
-    ![Create webhook - Dark Mode](/product-guide/screenshots/task-email-dark.png#only-dark) 
+    ![Create webhook - Light Mode](../../product-guide/screenshots/task-email-light.png#only-light)
+    ![Create webhook - Dark Mode](../../product-guide/screenshots/task-email-dark.png#only-dark) 
 
  
 ??? step-detail "3. Create a Task to Send the Webhook"
@@ -69,8 +69,8 @@ Using VergeOS Task Engine components, administrators can instantly trigger alert
 
     ***System > Tasks Dashboard > New Task***
 
-    ![Create Slack webhook task - Light Mode](/product-guide/screenshots/task-webhook-light.png#only-light)
-    ![Create Slack webhook task - Dark Mode](/product-guide/screenshots/task-webhook-dark.png#only-dark) 
+    ![Create Slack webhook task - Light Mode](../../product-guide/screenshots/task-webhook-light.png#only-light)
+    ![Create Slack webhook task - Dark Mode](../../product-guide/screenshots/task-webhook-dark.png#only-dark) 
 
 ??? step-detail "4. Assign an Event Trigger to the *Send-slack-payload* Task"
 
@@ -79,8 +79,8 @@ Using VergeOS Task Engine components, administrators can instantly trigger alert
     From the *Send-slack-payload* task dashboard:
     ***Event Triggers > New*** 
 
-    ![Assign Event Trigger to Slack Task- Light Mode](/product-guide/screenshots/slack-send-event-trigger-light.png#only-light)
-    ![Assign Event Trigger to Slack Task- Dark Mode](/product-guide/screenshots/slack-send-event-trigger-dark.png#only-dark) 
+    ![Assign Event Trigger to Slack Task- Light Mode](../../product-guide/screenshots/slack-send-event-trigger-light.png#only-light)
+    ![Assign Event Trigger to Slack Task- Dark Mode](../../product-guide/screenshots/slack-send-event-trigger-dark.png#only-dark) 
 
 ??? step-detail "5. Assign an Event Trigger to the *'send-email-alert'* Task"
     
@@ -88,8 +88,8 @@ Using VergeOS Task Engine components, administrators can instantly trigger alert
 
     ***System > Tasks Dashboard > Tasks >*** select the *send-email-alert* task ***> Event Triggers > New***
 
-    ![Assign Event Trigger to Email Task - Light Mode](/product-guide/screenshots/send-email-event-trigger-light.png#only-light)
-    ![Assign Event Trigger to Email Task - Dark Mode](/product-guide/screenshots/send-email-event-trigger-dark.png#only-dark) 
+    ![Assign Event Trigger to Email Task - Light Mode](../../product-guide/screenshots/send-email-event-trigger-light.png#only-light)
+    ![Assign Event Trigger to Email Task - Dark Mode](../../product-guide/screenshots/send-email-event-trigger-dark.png#only-dark) 
 
 This automation ensures that administrators are notified immediately when a sync job encounters an error, allowing them to act promptly, providing the best chance to resolve the issue before the synchronization window closes. 
 

--- a/docs/knowledge-base/posts/best-practices-pfsense-firewall.md
+++ b/docs/knowledge-base/posts/best-practices-pfsense-firewall.md
@@ -46,7 +46,7 @@ In certain environments, pfSense may experience network performance issues like 
     - Within the pfSense UI, navigate to **System** > **Advanced** > **Networking** and disable **Hardware Checksum Offloading**.
     - When enabled, pfSense offloads the processing of checksums to the virtual NIC. However, this feature is better suited for physical NICs, and in virtualized environments, it can cause performance degradation by generating unnecessary processing overhead on the virtual machine.
   
-  ![pfSense NIC Offloading Settings](/product-guide/screenshots/pfsense-offloading.png)
+  ![pfSense NIC Offloading Settings](../../product-guide/screenshots/pfsense-offloading.png)
 
 ## 3. Assigning Adequate Resources
 

--- a/docs/knowledge-base/posts/enable-ssh.md
+++ b/docs/knowledge-base/posts/enable-ssh.md
@@ -42,12 +42,12 @@ dateCreated: 2022-07-11T18:16:54.516Z
 SSH Access rules are auto-created, and disabled, during system installation.
 
 1. **Enable the core network rule:** Navigate to the Core network dashboard, modify the ***"SSH Access"*** rule, select the **Enabled** option and **Submit** to save the change.
-![ssh-rule-core.png](/product-guide/screenshots/ssh-rule-core.png)
+![ssh-rule-core.png](../../product-guide/screenshots/ssh-rule-core.png)
 
 2. **Add source control to the external network rule:** Navigate to the external network dashboard, modify the ***"SSH Access"*** rule to **configure specific source IP address(es) and/or address range(s) to tightly control access**.
 3. **Enable the external network rule:** select the **Enabled** option and **Submit** to save the change.  
 **Ex. External Network Rule:**
-![ssh-rule-external.png](/product-guide/screenshots/ssh-rule-external.png)
+![ssh-rule-external.png](../../product-guide/screenshots/ssh-rule-external.png)
 
 4. **Apply Rules** to both networks.
 

--- a/docs/knowledge-base/posts/example-tasks.md
+++ b/docs/knowledge-base/posts/example-tasks.md
@@ -51,14 +51,14 @@ The automation consists of creating tags, defining tasks, and attaching event an
     
     ***System >  Tags >  New*** 
        
-    ![Create tag category - Light Mode](/product-guide/screenshots/new-tag-category-vms-light.png#only-light)
-    ![Create tag category - Dark Mode](/product-guide/screenshots/new-tag-category-vms-dark.png#only-dark) 
+    ![Create tag category - Light Mode](../../product-guide/screenshots/new-tag-category-vms-light.png#only-light)
+    ![Create tag category - Dark Mode](../../product-guide/screenshots/new-tag-category-vms-dark.png#only-dark) 
 
     **Double-click category created above >**  ***New***   
     
-    ![New tag - Light Mode](/product-guide/screenshots/create-vm-tag-light.png#only-light)
+    ![New tag - Light Mode](../../product-guide/screenshots/create-vm-tag-light.png#only-light)
 
-    ![New tag - Dark Mode](/product-guide/screenshots/create-vm-tag-dark.png#only-dark)
+    ![New tag - Dark Mode](../../product-guide/screenshots/create-vm-tag-dark.png#only-dark)
 
 
 ??? step-detail "2. Assign the Tag to the VMs to Automatically Power On/Off"
@@ -67,16 +67,16 @@ The automation consists of creating tags, defining tasks, and attaching event an
 
     ***Virtual Machines >  List >***  **select VMs >**  ***Assign Tags*** **> select the tag from above**  
 
-    ![Assign tag to VMs - Light Mode](/product-guide/screenshots/assign-tag-vms-light.png#only-light)
+    ![Assign tag to VMs - Light Mode](../../product-guide/screenshots/assign-tag-vms-light.png#only-light)
 
-    ![Assign tag to VMs - Dark Mode](/product-guide/screenshots/assign-tag-vms-dark.png#only-dark) 
+    ![Assign tag to VMs - Dark Mode](../../product-guide/screenshots/assign-tag-vms-dark.png#only-dark) 
 
 
     The VMs will now show the assigned tag in the ***Tags*** column.
 
-    ![VMs with tag - Light Mode](/product-guide/screenshots/vms-tags-column-light.png#only-light)
+    ![VMs with tag - Light Mode](../../product-guide/screenshots/vms-tags-column-light.png#only-light)
 
-    ![VMs with tag - Dark Mode](/product-guide/screenshots/vms-tags-column-dark.png#only-dark)
+    ![VMs with tag - Dark Mode](../../product-guide/screenshots/vms-tags-column-dark.png#only-dark)
 
 
 ??? step-detail "3. Create a Task to Power On VMs"
@@ -85,9 +85,9 @@ The automation consists of creating tags, defining tasks, and attaching event an
 
     ***System > Tasks Dashboard > New Task***
 
-    ![Task to power on tagged VMs - Light Mode](/product-guide/screenshots/task-poweron-jthompson-light.png#only-light)
+    ![Task to power on tagged VMs - Light Mode](../../product-guide/screenshots/task-poweron-jthompson-light.png#only-light)
 
-    ![Task to power on tagged VMs  - Dark Mode](/product-guide/screenshots/task-poweron-jthompson-dark.png#only-dark)   
+    ![Task to power on tagged VMs  - Dark Mode](../../product-guide/screenshots/task-poweron-jthompson-dark.png#only-dark)   
 
 ??? step-detail "4. Configure an Event Trigger for User Login"
 
@@ -96,9 +96,9 @@ The automation consists of creating tags, defining tasks, and attaching event an
     From the new task dashboard:
     ***Event Triggers > New*** 
 
-    ![Event trigger user login - Light Mode](/product-guide/screenshots/jthompson-event-login-light.png#only-light)
+    ![Event trigger user login - Light Mode](../../product-guide/screenshots/jthompson-event-login-light.png#only-light)
 
-    ![Event trigger user login - Dark Mode](/product-guide/screenshots/jthompson-event-login-dark.png#only-dark) 
+    ![Event trigger user login - Dark Mode](../../product-guide/screenshots/jthompson-event-login-dark.png#only-dark) 
 
 
 ??? step-detail "5. Create a Task to Power Off the VMs"
@@ -107,9 +107,9 @@ The automation consists of creating tags, defining tasks, and attaching event an
 
     ***System > Tasks Dashboard > New Task***
 
-    ![Task to power off tagged VMs - Light Mode](/product-guide/screenshots/task-poweroff-jthompson-light.png#only-light)
+    ![Task to power off tagged VMs - Light Mode](../../product-guide/screenshots/task-poweroff-jthompson-light.png#only-light)
 
-    ![Task to power off tagged VMs - Dark Mode](/product-guide/screenshots/task-poweroff-jthompson-dark.png#only-dark) 
+    ![Task to power off tagged VMs - Dark Mode](../../product-guide/screenshots/task-poweroff-jthompson-dark.png#only-dark) 
 
 
 ??? step-detail "6. Configure an Event Trigger for User Logout"
@@ -119,9 +119,9 @@ The automation consists of creating tags, defining tasks, and attaching event an
     From the new task dashboard:  
     ***Event Triggers > New***
 
-    ![Event trigger user logout - Light Mode](/product-guide/screenshots/jthompson-event-logoff-light.png#only-light)
+    ![Event trigger user logout - Light Mode](../../product-guide/screenshots/jthompson-event-logoff-light.png#only-light)
 
-    ![Event trigger user logout - Dark Mode](/product-guide/screenshots/jthompson-event-logoff-dark.png#only-dark) 
+    ![Event trigger user logout - Dark Mode](../../product-guide/screenshots/jthompson-event-logoff-dark.png#only-dark) 
 
 ??? step-detail "7. Create a Schedule for Fridays at 6:00pm"
 
@@ -129,9 +129,9 @@ The automation consists of creating tags, defining tasks, and attaching event an
 
     ***System > Tasks Dashboard > New Schedule***
 
-    ![Schedule COB - Light Mode](/product-guide/screenshots/schedule-eob-friday-light.png#only-light)
+    ![Schedule COB - Light Mode](../../product-guide/screenshots/schedule-eob-friday-light.png#only-light)
 
-    ![Schedule COB - Dark Mode](/product-guide/screenshots/schedule-eob-friday-dark.png#only-dark) 
+    ![Schedule COB - Dark Mode](../../product-guide/screenshots/schedule-eob-friday-dark.png#only-dark) 
 
 ??? step-detail "8. Create a Schedule Trigger for the Power Off"
 
@@ -140,9 +140,9 @@ The automation consists of creating tags, defining tasks, and attaching event an
     From the dashboard of the new task:  
     ***Schedule Triggers > New***
 
-    ![Schedule trigger - Light Mode](/product-guide/screenshots/jthompson-schedule-poweroff-light.png#only-light)
+    ![Schedule trigger - Light Mode](../../product-guide/screenshots/jthompson-schedule-poweroff-light.png#only-light)
 
-    ![Schedule trigger - Dark Mode](/product-guide/screenshots/jthompson-schedule-poweroff-dark.png#only-dark) 
+    ![Schedule trigger - Dark Mode](../../product-guide/screenshots/jthompson-schedule-poweroff-dark.png#only-dark) 
 
 ### Verification
 - Log in as JThompson → tagged VMs should power on automatically

--- a/docs/knowledge-base/posts/ipsec-example-dedicated-ip-bridged.md
+++ b/docs/knowledge-base/posts/ipsec-example-dedicated-ip-bridged.md
@@ -43,26 +43,26 @@ The following IPsec example utilizes a dedicated public IP address for a VPN tun
 ## Static Lease
 We navigate to ***Internal-xyz** > IP Addresses > New** to reserve a static address for the VPN router on this internal network in order avoiding another entity from taking the same IP address. Full instructions for creating a static lease can be found here: [Create a DHCP Static Lease](/product-guide/networks/dhcp-static-lease).
 
-![VPN Static Lease](/assets/ipsec-dedicated-bridged-staticlease.png)
+![VPN Static Lease](../../assets/ipsec-dedicated-bridged-staticlease.png)
 
 ## VPN Network Configuration
  
-![VPN Network Config](/assets/ipsec-dedicated-bridged-vpn-network.png)
+![VPN Network Config](../../assets/ipsec-dedicated-bridged-vpn-network.png)
 
 
 ## Phase 1
 
-![Phase 1 Configuration](/assets/ipsec-dedicated-bridged-phase1.png)
+![Phase 1 Configuration](../../assets/ipsec-dedicated-bridged-phase1.png)
 
 ## Phase 2
 
-![Phase 2 Configuration](/assets/ipsec-dedicated-bridged-phase2.png)
+![Phase 2 Configuration](../../assets/ipsec-dedicated-bridged-phase2.png)
 
 
 ## Assigned Public IP Address
 The public address must be [Assigned from the External network](/product-guide/networks/assign-external-ip) to the VPN network.
 
-![Assign Public IP](/assets/ipsec-dedicated-bridged-provide-public.png)
+![Assign Public IP](../../assets/ipsec-dedicated-bridged-provide-public.png)
 
 
 ## Default VPN Network Rules
@@ -75,7 +75,7 @@ The following necessary firewall rules are **created automatically** when a VPN 
 * **Allow ESP**: Accept incoming ESP protocol traffic to **My Router IP**
 * **Allow AH**: Accept incoming AH protocol traffic to **My Router IP**
 
-![Review Rules](/assets/ipsec-defaultrules.png)
+![Review Rules](../../assets/ipsec-defaultrules.png)
 
 !!! tip "These rules can be modified to restrict to specific source addresses, where appropriate."
 
@@ -84,19 +84,19 @@ The following necessary firewall rules are **created automatically** when a VPN 
 Additional rules need to be created on our new VPN network:
 
 **Translate Rule:**
-![VPN Translate to Router](/assets/ipsec-dedicated-bridged-vpn-translate.png)
+![VPN Translate to Router](../../assets/ipsec-dedicated-bridged-vpn-translate.png)
 
 !!! note "The translate rule must be moved to the top of the rules list, before the *Accept* Rules.  Instructions for changing the order of rules can be found in the Product Guide: [Network Rules - Change the Order of Rules](/product-guide/networks/network-rules/#change-the-order-of-rules)"
 
 **Default Route Rule:**
-![VPN Default Route Rule](/assets/ipsec-dedicated-bridged-vpn-defroute.png)
+![VPN Default Route Rule](../../assets/ipsec-dedicated-bridged-vpn-defroute.png)
 
 
 ## Internal Network Rule
 
 A routing rule is needed on *Internal-xyz* to route its VPN traffic to the VPN network.
 
-![VPN Default Route Rule](/assets/ipsec-dedicated-bridged-internal-route.png)
+![VPN Default Route Rule](../../assets/ipsec-dedicated-bridged-internal-route.png)
 
 
 !!! tip "New rules must be applied on each network to put them into effect."

--- a/docs/knowledge-base/posts/ipsec-example-tenant-nat-ui-address.md
+++ b/docs/knowledge-base/posts/ipsec-example-tenant-nat-ui-address.md
@@ -44,16 +44,16 @@ Assigning the UI address to a tenant automatically creates rules on the host sys
 
 ## VPN Network Configuration
 
-![VPN Network Configuration](/assets/tenant-ipsec-networkconfig.png)
+![VPN Network Configuration](../../assets/tenant-ipsec-networkconfig.png)
 
 
 ## Phase 1
 
-![Phase 1 Configuration](/assets/tenant-ipsec-phase1.png)
+![Phase 1 Configuration](../../assets/tenant-ipsec-phase1.png)
 
 ## Phase 2 
 
-![Phase 2 Configuration](/assets/tenant-ipsec-phase2.png)
+![Phase 2 Configuration](../../assets/tenant-ipsec-phase2.png)
 
 
 ## Default VPN Network Rules
@@ -66,7 +66,7 @@ The following necessary firewall rules are **created automatically** when a VPN 
 * **Allow ESP**: Accept incoming ESP protocol traffic to **My Router IP**
 * **Allow AH**: Accept incoming AH protocol traffic to **My Router IP**
 
-![Review Rules](/assets/ipsec-defaultrules.png)
+![Review Rules](../../assets/ipsec-defaultrules.png)
 
 !!! tip "These rules can be modified to restrict to specific source addresses, where appropriate."
 
@@ -76,15 +76,15 @@ The following necessary firewall rules are **created automatically** when a VPN 
 Additional rules need to be created on our new VPN network:
 
 **VPN NAT Rule:**
-![VPN NAT Rule](/assets/tenant-ipsec-vpn-rule-translate.png)
+![VPN NAT Rule](../../assets/tenant-ipsec-vpn-rule-translate.png)
 
 !!! tip "The incoming NAT rule must be moved to the top, before the *Accept* Rules. Instructions for changing the order of rules can be found in the Product Guide: [Network Rules - Change the Order of Rules](/product-guide/networks/network-rules/#change-the-order-of-rules)"
 **Default Route Rule:**
-![VPN Default Route Rule](/assets/tenant-ipsec-vpn-rule-default-route.png)
+![VPN Default Route Rule](../../assets/tenant-ipsec-vpn-rule-default-route.png)
 
 
 **VPN SNAT Rule:**
-![VPN Nat Rule](/assets/tenant-ipsec-vpn-rule-outgoing-snat.png)
+![VPN Nat Rule](../../assets/tenant-ipsec-vpn-rule-outgoing-snat.png)
 
 
 ## External Network Rules
@@ -92,13 +92,13 @@ Additional rules need to be created on our new VPN network:
 Translate rules are necessary on the tenant's external network, to send IPsec traffic to the VPN network: 
 
 **External UDP NAT Rule:**
-![VPN Nat Rule](/assets/tenant-ipsec-external-udp-rule.png)
+![VPN Nat Rule](../../assets/tenant-ipsec-external-udp-rule.png)
 
 **External ESP NAT Rule:**
-![VPN Nat Rule](/assets/tenant-ipsec-external-ESP-rule.png)
+![VPN Nat Rule](../../assets/tenant-ipsec-external-ESP-rule.png)
 
 **External AH NAT Rule:**
-![VPN Nat Rule](/assets/tenant-ipsec-external-AH-rule.png)
+![VPN Nat Rule](../../assets/tenant-ipsec-external-AH-rule.png)
 
 
 ## Connecting Internal Networks to the VPN 

--- a/docs/knowledge-base/posts/non-persistent-vm.md
+++ b/docs/knowledge-base/posts/non-persistent-vm.md
@@ -35,9 +35,9 @@ A Non-Persistent VM reverts to its original state after a reboot, discarding any
        This ensures the data is in a good state for cloning.
 
 3. Click the **Copy** button next to the main disk on the VM.
-   ![nonpersistent-2.png](/product-guide/screenshots/non-persistent-copy.png)
+   ![nonpersistent-2.png](../../product-guide/screenshots/non-persistent-copy.png)
 4. Change the **Media Type** to **Non-Persistent** and click **Submit** at the bottom.
-5. Click the **Edit** icon ![edit icon pencil](/product-guide/screenshots/edit-icon-pencil.png) for the original **Disk Media Type**.
+5. Click the **Edit** icon ![edit icon pencil](../../product-guide/screenshots/edit-icon-pencil.png) for the original **Disk Media Type**.
 !!! note
    The new disk will show a **Media Type** of **Non-Persistent**. Any changes made to this disk will be reverted upon a reboot of the VM.
 6. Uncheck the **Enabled** checkbox.

--- a/docs/knowledge-base/posts/proxy.md
+++ b/docs/knowledge-base/posts/proxy.md
@@ -51,7 +51,7 @@ Using a Proxy grants the ability to use 1 IP address for multiple Tenant environ
    - Select **Rules**.
    - Create a new rule that looks like the following image:
    
-   ![proxy_accept_rule.png](/product-guide/screenshots/proxy_accept_rule.png)
+   ![proxy_accept_rule.png](../../product-guide/screenshots/proxy_accept_rule.png)
    
    - Restart the network and apply the rules.
    - Test the rule by opening a browser tab and navigating to the URL using the IP Alias address assigned in the previous step. If it works properly, the UI login page will open on the IP Alias address.
@@ -93,7 +93,7 @@ Using a Proxy grants the ability to use 1 IP address for multiple Tenant environ
 
 7. Select the tenant network (highlighted) from the tenant dashboard.
 
-   ![tenant_apply_rules.png](/product-guide/screenshots/tenant_apply_rules.png)
+   ![tenant_apply_rules.png](../../product-guide/screenshots/tenant_apply_rules.png)
 
 8. Select **Apply Rules** in the highlighted warning.
 

--- a/docs/knowledge-base/posts/reviewing-system-logs.md
+++ b/docs/knowledge-base/posts/reviewing-system-logs.md
@@ -54,7 +54,7 @@ System logs are essential for monitoring and troubleshooting the performance and
 
 The log in the following screenshot shows several specific events as examples of logged activity.
 
-![system_logs.png](/product-guide/screenshots/system_logs.png)
+![system_logs.png](../../product-guide/screenshots/system_logs.png)
 
 - From the entry time-stamped on March 28th, 2022 at 9:21:35, there is a record of the IP address from where the admin user logged in, along with the date and time of the login.
 - The entry at 9:21:55 shows that the user named 'admin' had the password changed from the root environment.

--- a/docs/knowledge-base/posts/tenant-statistics.md
+++ b/docs/knowledge-base/posts/tenant-statistics.md
@@ -35,7 +35,7 @@ dateCreated: 2023-03-16T15:25:45.176Z
 - Choose your month/year and click **Apply**
 - Scroll down to the bottom.
   
-![consumptionstats-image_(14).png](/product-guide/screenshots/consumptionstats-image14.png)
+![consumptionstats-image_(14).png](../../product-guide/screenshots/consumptionstats-image14.png)
 
 **RAM Consumption**: Total RAM Allocated 95th percentile  
 **Storage Consumption**: Tier X (Provisioned) - add up all tiers at the 95th percentile

--- a/docs/knowledge-base/posts/understanding-traffic-flow.md
+++ b/docs/knowledge-base/posts/understanding-traffic-flow.md
@@ -28,17 +28,17 @@ dateCreated: 2023-11-29T16:50:57.491Z
 ---
 
 ## Traffic/Network Flow Diagram
-![VergeOS-traffic-flow_(1).png](/product-guide/screenshots/vergeio-traffic-flow_(1).png)
+![VergeOS-traffic-flow_(1).png](../../product-guide/screenshots/vergeio-traffic-flow_%281%29.png)
 
 <br>
 
 ## Example of an External Network using VLAN 55 and an Internal Network
-![vnet_wiring.png](/product-guide/screenshots/vnet_wiring.png)
+![vnet_wiring.png](../../product-guide/screenshots/vnet_wiring.png)
 
 <br>
 
 ## Example of the Core Network Configuration
-![core_config.jpg](/product-guide/screenshots/core_config.jpg)
+![core_config.jpg](../../product-guide/screenshots/core_config.jpg)
 
 <br>
 

--- a/docs/knowledge-base/posts/unexpected-vsan-growth.md
+++ b/docs/knowledge-base/posts/unexpected-vsan-growth.md
@@ -52,7 +52,7 @@ To isolate unexplained growth, it is important to narrow down when the growth in
 - When reviewing by week, check if the total storage consumed at the start of the week is similar to the end. If, for example, the growth is roughly 10%, repeat for the previous week. If the weekly growth percentage is consistent, this represents your average weekly growth rate, which can help plan for hardware expansion.
 - Filter the current month and check for any sudden spikes in storage consumption on the **Storage Usage** graph. Click and drag over the time in question to zoom in on the data, and hover over the graph for specific date/time information.
 
-![vsan_unexpected_growth.png](/product-guide/screenshots/vsan_unexpected_growth.png)
+![vsan_unexpected_growth.png](../../product-guide/screenshots/vsan_unexpected_growth.png)
 
 ## Possible Reasons for Storage Increase
 

--- a/docs/knowledge-base/posts/vergeio-update-instructions.md
+++ b/docs/knowledge-base/posts/vergeio-update-instructions.md
@@ -56,10 +56,10 @@ The time required to complete an update varies depending on factors such as:
    
     - A pop-up will prompt Yes or No, select **Yes**.
     - If a banner appears stating "A new minor version is available on a different branch," follow the prompt to change branches by selecting **Change Branch** in the left menu. Confirm with **Yes**.
-   ![VergeOSupgrade-new-img2.png](/product-guide/screenshots/vergeioupgrade-new-img2.png)
+   ![VergeOSupgrade-new-img2.png](../../product-guide/screenshots/vergeioupgrade-new-img2.png)
 
 3. The packages to be downloaded will now be highlighted.
-   ![VergeOSupgrade-new-img3.png](/product-guide/screenshots/vergeioupgrade-new-img3.png)
+   ![VergeOSupgrade-new-img3.png](../../product-guide/screenshots/vergeioupgrade-new-img3.png)
     - Select **Download** in the left menu.
     - A pop-up will prompt Yes or No, select **Yes**.
     - The download process will appear on the dashboard in the **Current Update Server** tile.
@@ -82,7 +82,7 @@ The time required to complete an update varies depending on factors such as:
 ### vSAN Taking a Long Time to Verify
 - The verification process depends on factors like network speed, disk type, and consumed data. HDDs will take longer than NVMe or SSDs. On VergeOS versions 4.9.0 and higher, check the **Full Walk Progress** on the tiers dashboard for an indication of how far along the verification is.
   
-    ![walk-percentage.png](/product-guide/screenshots/walk-percentage.png)
+    ![walk-percentage.png](../../product-guide/screenshots/walk-percentage.png)
 
 !!! danger "WARNING"
     This process must complete before rebooting any additional nodes. Failure to do so can result in a **double failure**, causing workloads to crash.

--- a/docs/knowledge-base/posts/vmware-backup-dr-guide.md
+++ b/docs/knowledge-base/posts/vmware-backup-dr-guide.md
@@ -74,7 +74,7 @@ The VMware service establishes a direct agent connection with vSphere; network a
 ---
 
 ### vSphere Settings:
-![dr1-1.png](/product-guide/screenshots/dr1-1.png)
+![dr1-1.png](../../product-guide/screenshots/dr1-1.png)
 
 1.  Enter the **vSphere DNS or IP** (required).  The address should be reachable from the network selected for the service. 
 
@@ -159,19 +159,19 @@ At this point the Schedule is just an empty container; one or more tasks need to
 
 ***Ex: Every weekday  at 5:15 PM***
 
-![dr3.png](/product-guide/screenshots/dr3.png)  
+![dr3.png](../../product-guide/screenshots/dr3.png)  
 
 ***Ex: Every 2 hours, from 7 AM - 5 PM, except for Sunday:***
 
-![dr4.png](/product-guide/screenshots/dr4.png)
+![dr4.png](../../product-guide/screenshots/dr4.png)
 
 ***Ex: Monthly, on the last day of the month:***
 
-![dr6.png](/product-guide/screenshots/dr6.png)
+![dr6.png](../../product-guide/screenshots/dr6.png)
 
 ***Ex: One time only, on 2019-04-01 at Noon:***
 
-![dr7.png](/product-guide/screenshots/dr7.png)
+![dr7.png](../../product-guide/screenshots/dr7.png)
 
 10.  By default, a recurring Task is set to run perpetually.  **Optionally,  a Task Expiration** can be defined which will cause the Task to cease on the selected date and time.  To set an expiration for the Task: De-select the Never checkbox and enter desired expiration date and time. 
 
@@ -220,7 +220,7 @@ At this point the Schedule is just an empty container; one or more tasks need to
 
 ## Assigning Schedules
 Once the VMware service is created and successfully connects to the VSphere system, the list of discovered VMware Virtual Machines will appear on the VMware Service Dashboard.   
-![dr8.png](/product-guide/screenshots/dr8.png)
+![dr8.png](../../product-guide/screenshots/dr8.png)
 By default, all VMs have their schedule set to --None--.
 
 ---

--- a/docs/knowledge-base/posts/windows-time-shift.md
+++ b/docs/knowledge-base/posts/windows-time-shift.md
@@ -48,7 +48,7 @@ VergeOS provides time in UTC, which has become the industry standard as it compe
 
 RTC Base is an individual VM setting that allows VergeOS administrators to set the time provided to the OS as either local or UTC. The value can be found when editing any VM.
 
-![alt text](/product-guide/screenshots/rtcbase-utc-screenshot.png)
+![alt text](../../product-guide/screenshots/rtcbase-utc-screenshot.png)
 
 With this configuration setting, administrators can granularly control every machine, though it is important to understand the expected behavior of each option.
 

--- a/docs/knowledge-base/posts/wireguard-setup-remote-access-vpn.md
+++ b/docs/knowledge-base/posts/wireguard-setup-remote-access-vpn.md
@@ -42,7 +42,7 @@ Here are instructions on how to set up a Remote Access VPN using the built-in Wi
 1. In the Verge OS UI, navigate to **Networks -> Internals** and view or **double-click** on the Internal Network that you want to use.
 2. In the left menu, click on **Wireguard (VPN)**.
 3. Click on **Add New Interface**.
-   ![wireguardvpn-img1.png](/product-guide/screenshots/wireguardvpn-img1.png)
+   ![wireguardvpn-img1.png](../../product-guide/screenshots/wireguardvpn-img1.png)
 
 4. Enter the following information:
     - Enter a unique **Name** for this interface.
@@ -52,20 +52,20 @@ Here are instructions on how to set up a Remote Access VPN using the built-in Wi
     - Enter the **Listen Port** to be used when connecting to the VPN (**Default: 51820**). This is the port that you will use on your External network to send VPN traffic into your Internal Network.
     - Enter a **Private Key** or leave it blank to auto-generate a key.
     - Enter an **Endpoint IP** or leave it blank, and the system will attempt to auto-detect the IP. We **highly recommend** you enter the IP manually to ensure the correct config. This IP is the external IP of your environment, usually the same IP as your UI. You can find your External IP by going to **Networks -> Externals** and viewing your External network. In the Network Router section, it should be the IP address as shown below:
-    ![wireguardvpn-img3-fixed.png](/product-guide/screenshots/wireguardvpn-img3-fixed.png)
+    ![wireguardvpn-img3-fixed.png](../../product-guide/screenshots/wireguardvpn-img3-fixed.png)
 
 5. Click **Submit** to add the new interface.
 6. After adding the interface, it will take you to the dashboard where you will see your new interface.  
-   ![wireguardvpn-img2.png](/product-guide/screenshots/wireguardvpn-img2.png)
+   ![wireguardvpn-img2.png](../../product-guide/screenshots/wireguardvpn-img2.png)
 
 7. Click **Apply Rules** on the left menu bar to apply the firewall rules. The rules automatically created will accept inbound UDP traffic on port 51820 to both the Router IP and the DMZ IP of the **Internal Network**.
-   ![wireguardvpn-img-intrules.png](/product-guide/screenshots/wireguardvpn-img-intrules.png)
+   ![wireguardvpn-img-intrules.png](../../product-guide/screenshots/wireguardvpn-img-intrules.png)
 
 ### External Network PAT Rule
 
 In order for the internal network to be connected, we need an external **PAT** (Port Address Translation) rule to translate the port (**default 51820**) to the **internal network**.
 
-![2023-09-06_11_56_18-training___rules.png](/product-guide/screenshots/wireguard-pat-rule.png)
+![2023-09-06_11_56_18-training___rules.png](../../product-guide/screenshots/wireguard-pat-rule.png)
 
 #### Add External PAT Rule
 
@@ -132,7 +132,7 @@ If you are adding **Wireguard** and are not using the IP address of the **UI**, 
 !!! note "You will set up a **Peer** for each user connecting to the VPN."
 
 1. From the Wireguard Interface screen, click **Add new peer**.
-   ![wireguardvpn-img4.png](/product-guide/screenshots/wireguardvpn-img4.png)
+   ![wireguardvpn-img4.png](../../product-guide/screenshots/wireguardvpn-img4.png)
 
 2. Assign a **Name** to the peer, such as the remote user's name.
 3. Optionally, enter a **Description**.
@@ -141,14 +141,14 @@ If you are adding **Wireguard** and are not using the IP address of the **UI**, 
 6. For **Allowed IPs**, enter the /32 IP for this peer.
 7. In the **Configure Firewall** dropdown, select **Remote User**.
 8. Click **Submit** to save the peer entry.
-   ![wireguardvpn-img6.png](/product-guide/screenshots/wireguardvpn-img6.png)
+   ![wireguardvpn-img6.png](../../product-guide/screenshots/wireguardvpn-img6.png)
 
 #### Download the Configuration File:
 
 9. Click the **Download Config** button on the peer record and download the file.
 
-   ![download-link.png](/product-guide/screenshots/download-link.png)
-   ![configuration-file.png](/product-guide/screenshots/configuration-file.png)
+   ![download-link.png](../../product-guide/screenshots/download-link.png)
+   ![configuration-file.png](../../product-guide/screenshots/configuration-file.png)
 
 #### Install WireGuard Software on Client:
 
@@ -158,7 +158,7 @@ WireGuard client software can be downloaded from: [https://wireguard.com/install
 2. Click **Add Tunnel**.
 3. Navigate to and select the generated configuration file.
 4. Click the **Activate** button to open the tunnel.
-   ![tunnel-active.png](/product-guide/screenshots/tunnel-active.png)
+   ![tunnel-active.png](../../product-guide/screenshots/tunnel-active.png)
 
 ---
 

--- a/docs/product-guide/auth/azure-auth.md
+++ b/docs/product-guide/auth/azure-auth.md
@@ -35,9 +35,9 @@ VergeOS can be configured to allow users to authenticate using their corporate A
 ## Configure an Entra ID Authorization Source
 
 1. In Azure services: register a single-tenant web application, setting the ***Redirect URI*** to the URL of the VergeOS system and creating a new client secret. **Azure Active Directory > App Registrations > New Registration**
-    ![azurereg1.png](/product-guide/screenshots/azurereg1.png)
+    ![azurereg1.png](../screenshots/azurereg1.png)
 
-    ![azurereg2.png](/product-guide/screenshots/azurereg2.png)
+    ![azurereg2.png](../screenshots/azurereg2.png)
 
 2. Create a new client secret. **App Registrations > Client Credentials > Add a certificate or secret. Click +New client secret.**
    - Enter a **description and expiration date** for the new client secret.
@@ -46,14 +46,14 @@ VergeOS can be configured to allow users to authenticate using their corporate A
        - **Client ID** - **hint: *Azure App Registrations > Configured Item > Client Credentials***
        - **Client Secret** - **hint: *Azure App Registrations > Configured Item > Client Credentials* Use the "VALUE" field.**
 
-    ![azureclientsecretadd.png](/product-guide/screenshots/azureclientsecretadd.png)
-    ![azureclientsecret2.png](/product-guide/screenshots/azureclientsecret2.png)
+    ![azureclientsecretadd.png](../screenshots/azureclientsecretadd.png)
+    ![azureclientsecret2.png](../screenshots/azureclientsecret2.png)
 
 3. Click **System** on the top menu.
 4. Select **Auth Sources**.
 5. Click **New** on the left menu.
 6. Enter a ***Name*** for the source (such as "Azure"). This name will appear on the sign-in button of the VergeOS login page.
-    ![azureauthform.png](/product-guide/screenshots/azureauthform.png)
+    ![azureauthform.png](../screenshots/azureauthform.png)
 
 7. In the ***Driver*** field (dropdown list), select **Azure AD**.
 8. Enter the ***Tenant ID*** obtained in the previous step.
@@ -99,7 +99,7 @@ Interfacing with Azure groups requires a token on the Entra ID app registration 
 3. Check the appropriate **group types**.
 4. Set the **ID, Access, and SAML to sAMAccountName**.
 
-![azure-editgroupsclaim.pn](/product-guide/screenshots/azure-editgroupsclaim.png)
+![azure-editgroupsclaim.pn](../screenshots/azure-editgroupsclaim.png)
 
 ### Steps to Add Azure Groups
 
@@ -110,9 +110,9 @@ Interfacing with Azure groups requires a token on the Entra ID app registration 
 5. Copy the coordinating **Object Id** from the Groups/All Groups page in Entra ID to the ***Identifier*** field.
 6. Click **Submit** (bottom of the page) to save the new group.
 
-![azure-groupspage.png](/product-guide/screenshots/azure-groupspage.png)
+![azure-groupspage.png](../screenshots/azure-groupspage.png)
 
-![azure-creategroup.png](/product-guide/screenshots/azure-creategroup.png)
+![azure-creategroup.png](../screenshots/azure-creategroup.png)
 
 ## Manually Add Users from Azure
 
@@ -128,4 +128,4 @@ When creating the new user, use the following configuration:
 - ***Display Name:*** (optional) If *Update User Display Name* is enabled on the Entra ID auth source, display name will automatically synchronize from Entra ID.
 - ***Email Address:*** (optional) If *Update User Email Address* is enabled on the Entra ID auth source, email address will automatically synchronize from Entra ID.
 
-![azure-newuser.png](/product-guide/screenshots/azure-newuser.png)
+![azure-newuser.png](../screenshots/azure-newuser.png)

--- a/docs/product-guide/automation/vm-recipes.md
+++ b/docs/product-guide/automation/vm-recipes.md
@@ -49,11 +49,11 @@ VergeOS supports both **Cloud-Init** (Linux) and **Cloudbase-Init** (Windows) to
 
 A VergeOS system automatically includes the **Service Provider(Marketplace) Repository** comprised of VM recipes that can be used straightaway to create new virtual machines of many types.  The list of these available VM recipes can be viewed by navigating to **Repositories > (double-click) MarketPlace repository > VM Recipes**.
 
-![marketplaceVMlisting](/product-guide/screenshots/marketplaceVMlisting.png)
+![marketplaceVMlisting](../screenshots/marketplaceVMlisting.png)
 
  You can double-click on an individual VM recipe to view its configuration.  
 
-![included-recipe-config](/product-guide/screenshots/included-recipe-config.png)
+![included-recipe-config](../screenshots/included-recipe-config.png)
 
 ## Create a New VM Recipe
 

--- a/docs/product-guide/backup-dr/monitoring-site-syncs.md
+++ b/docs/product-guide/backup-dr/monitoring-site-syncs.md
@@ -30,7 +30,7 @@ Ongoing tracking of sync activity can be done from the sending system or the rec
 
 ## Outgoing Sync Dashboard (Sending System)
 
-![outgoingsync-dash.png](/product-guide/screenshots/outgoingsync-dash.png)
+![outgoingsync-dash.png](../screenshots/outgoingsync-dash.png)
 
 ### Sync Status
 
@@ -54,7 +54,7 @@ The most recent synchronized snapshots are displayed in the destination snapshot
 
 ## Incoming Sync Dashboard (Receiving System)
 
-![incomingsync-dash.png](/product-guide/screenshots/incomingsync-dash.png)
+![incomingsync-dash.png](../screenshots/incomingsync-dash.png)
 
 ### Sync Status
 
@@ -97,7 +97,7 @@ Subscriptions are available from both the sending system and the receiving syste
 6. Set the **Subscription profile** = ***Site Sync Dashboard***.
 7. Click **Submit** to save the subscription.
 
-![subscription-syncdash.png](/product-guide/screenshots/subscription-syncdash.png)
+![subscription-syncdash.png](../screenshots/subscription-syncdash.png)
 
 ### Receive a Notification each Time a New Sync is Completed (Receiving Site)
 
@@ -109,4 +109,4 @@ Subscriptions are available from both the sending system and the receiving syste
 6. Set **Subscription profile** = ***Site Sync Received***
 7. Click **Submit** to save the subscription.
 
-![subscription-syncreceived.png](/product-guide/screenshots/subscription-syncreceived.png)
+![subscription-syncreceived.png](../screenshots/subscription-syncreceived.png)

--- a/docs/product-guide/backup-dr/sync-configuration.md
+++ b/docs/product-guide/backup-dr/sync-configuration.md
@@ -76,7 +76,7 @@ Network rules are necessary to translate incoming sync traffic to the vSAN. Thes
 10. Define Target values:
     - **Type**: ***IP/Custom***
     - **Target IP**: ***ui*** (This is a VergeOS keyword; it must be entered in lower case, exactly as noted)
-![rule-core-vsanpat.png](/product-guide/screenshots/rule-core-vsanpat.png)
+![rule-core-vsanpat.png](../screenshots/rule-core-vsanpat.png)
 
 11. Click **Submit** to save the new rule.
 12. The system will prompt to Apply Rules. Click **Apply Rules** on the left menu to put the rule into effect.
@@ -106,7 +106,7 @@ Network rules are necessary to translate incoming sync traffic to the vSAN. Thes
 10. Define **Target** values:
     - **Type**: ***IP/Custom***
     - **Target**: ***ui*** (This is a VergeOS keyword; it must be entered in lower case, exactly as noted)
-![sync-snat.png](/product-guide/screenshots/sync-snat.png)
+![sync-snat.png](../screenshots/sync-snat.png)
 
 11. Click **Submit** to save the new rule.
 12. Click **Apply Rules** on the left menu to put the rule into effect.
@@ -196,7 +196,7 @@ When a specific tier(1-5) is selected here, the sync directs all data to the sel
 3. Double-click the desired outgoing sync to access its dashboard.
 4. In the **Auto Sync Configuration** section, click the **Add Item** link.  
 The Configuration form will appear.
-![sync-periodretention.png](/product-guide/screenshots/sync-periodretention.png)
+![sync-periodretention.png](../screenshots/sync-periodretention.png)
 
 5. In the **Sync Snapshots From** dropdown list, select a desired profile period (e.g. ***"Hourly for 3 hours"***, ***"Midnight"***, ***"Noon"***). The options that appear will depend on the periods defined in the snapshot profile assigned for the local system snapshots (by default, this will be the *System Snapshots* profile.)
 6. **Remote Retention** will default to the local retention of the selected period; change if a different retention setting is desired for the remote copy. (Changing the Remote Retention does not affect the local retention.)

--- a/docs/product-guide/networks/internal-external-access.md
+++ b/docs/product-guide/networks/internal-external-access.md
@@ -28,4 +28,4 @@ Giving an internal network external access requires having the proper default ga
 
 Select an appropriate external network in the **Default Gateway** field when creating a new internal network. The gateway will automatically create the appropriate routing rules to provide LAN and/or WAN access (depending on the physical connection/settings of the external network selected) to the internal network.
 
-![setdefgw.png](/product-guide/screenshots/setdefgw.png)
+![setdefgw.png](../screenshots/setdefgw.png)

--- a/docs/product-guide/networks/internal-layer2.md
+++ b/docs/product-guide/networks/internal-layer2.md
@@ -24,6 +24,6 @@ categories:
 
 Internal networks can be created as Layer2 (with layer 3 functions to be handled by third party software). To create a layer2 internal network, select ***None*** in the **IP Address Type** field.
 
-![internal-layer2.png](/product-guide/screenshots/internal-layer2.png)
+![internal-layer2.png](../screenshots/internal-layer2.png)
 
 Full instructions for creating an internal network can be found at: [**Internal Networks**](/product-guide/networks/internal-networks)

--- a/docs/product-guide/networks/internal-layer3.md
+++ b/docs/product-guide/networks/internal-layer3.md
@@ -26,6 +26,6 @@ categories:
 
 Internal networks can be created as Layer2 or Layer3. To create a layer3 internal network, in which DHCP, DNS, firewall, routing and throttling can be managed within VergeOS, select ***Static*** in the **IP Address Type** field.
 
-![internallayer3.png](/product-guide/screenshots/internallayer3.png)
+![internallayer3.png](../screenshots/internallayer3.png)
 
 Full instructions for creating a layer3 internal network can be found at: [**Internal Networks (General Instructions)**](/product-guide/networks/internal-networks).

--- a/docs/product-guide/networks/net-troubleshooting.md
+++ b/docs/product-guide/networks/net-troubleshooting.md
@@ -54,7 +54,7 @@ To check a network's addressing, see: [Determine Network Addresses](#determining
 1. Navigate to the **VM Dashboard**.
 2. Scroll down to the **NICs** section of the screen.
 If the network assigned a DHCP address to the NIC, it will display in the **IP Address** field.
-![troubleshooting-verifyipaddress.png](/product-guide/screenshots/troubleshooting-verifyipaddress.png)
+![troubleshooting-verifyipaddress.png](../screenshots/troubleshooting-verifyipaddress.png)
 
 3. **If an IP address was manually assigned within the guest OS (rather than utilizing DHCP):**
     -Verify assigned IP address lies within the network's address range.
@@ -73,7 +73,7 @@ VirtIO is generally the recommended interface for NIC devices, as it typically w
 1. Navigate to the **VM Dashboard**.
 2. Scroll down to the **NICs** section of the screen.
 3. The **Interface** column will display for each NIC.
-![troubleshooting-verifyinterface.png](/product-guide/screenshots/troubleshooting-verifyinterface.png)
+![troubleshooting-verifyinterface.png](../screenshots/troubleshooting-verifyinterface.png)
 
 ## Check Guest Firewalls and AV software
 
@@ -104,7 +104,7 @@ In order for an internal network to receive Internet connectivity, it must have 
 2. Click **Rules** on the left menu.
 3. Verify there is a route rule with the appropriate external network defined as the Target.  
 Example:
-![showdefgwrule.png](/product-guide/screenshots/showdefgwrule.png)
+![showdefgwrule.png](../screenshots/showdefgwrule.png)
 
 !!! success "When creating a new internal network, select the external network in the **Default Gateway** setting; this will automatically create the needed default gateway route rule. A route rule can also be manually created after network creation, using the following instructions."
 
@@ -120,7 +120,7 @@ Example:
 8. In the **Target Network** field, select the appropriate external network.
 
 Example:
-![defaultgw-create.png](/product-guide/screenshots/defaultgw-create.png)
+![defaultgw-create.png](../screenshots/defaultgw-create.png)
 
 ## Determining Network Addresses
 
@@ -129,7 +129,7 @@ A network's gateway address and network segment can be found on the network dash
 - **Network**: network segment in CIDR format (ex: 192.168.0.0/24; 10.10.0.0/24)
 - **IP Address**: network router address (ex: 192.168.01; 10.10.0.1)
 
-![findnetworkaddress.png](/product-guide/screenshots/findnetworkaddress.png)
+![findnetworkaddress.png](../screenshots/findnetworkaddress.png)
 
 !!! info "By default, internal layer-3 networks are configured with network segment: 192.168.0.0/24 and router IP Address: 192.168.0.1"
 

--- a/docs/product-guide/networks/network-rules.md
+++ b/docs/product-guide/networks/network-rules.md
@@ -153,7 +153,7 @@ For long rule lists, it may be helpful to filter the list (e.g. display Incoming
 5. Click **Submit** to save the change.
    - A right-side-up pin icon indicates the rule is pinned to the top
    - An upside-down pin icon indicates the rule is pinned to the bottom
-![pinnedrules.png](/product-guide/screenshots/pinnedrules.png)
+![pinnedrules.png](../screenshots/pinnedrules.png)
 
 ## Change the Order of Rules
 

--- a/docs/product-guide/networks/port-mirroring.md
+++ b/docs/product-guide/networks/port-mirroring.md
@@ -29,7 +29,7 @@ Port mirroring replicates a network's traffic to a VM NIC, allowing packet analy
 ## Configure Port Mirroring
 
 1. Enable **Port Mirroring** in the network settings.
-![portmirrordropdown.png](/product-guide/screenshots/portmirrordropdown.png)
+![portmirrordropdown.png](../screenshots/portmirrordropdown.png)
     - Select ***North/South*** to copy packets that traverse the network router
     - Select ***East/West*** to copy packets that traverse the router AND all intranetwork packets
 !!! warning "***East/West*** port mirroring is typically only recommended as a temporary setting for diagnostics purposes; using it for long durations can impact performance as it replicates all network traffic."

--- a/docs/product-guide/networks/tracking-net-statistics.md
+++ b/docs/product-guide/networks/tracking-net-statistics.md
@@ -60,6 +60,6 @@ See directions below for viewing the tracked statistics.
 2. Right-click on the columns heading section at the top.
 3. Check the boxes for **Packets** and/or **Bytes** to display these columns.
 
-![Show Statistics](/product-guide/screenshots/trackstats-cols.png)
+![Show Statistics](../screenshots/trackstats-cols.png)
 
 !!! success "Enabling the Statistics column will show if statistics tracking is enabled for each rule."

--- a/docs/product-guide/operations/drive-replacement.md
+++ b/docs/product-guide/operations/drive-replacement.md
@@ -34,14 +34,14 @@ This page covers replacing a drive (participating in the vSAN) due to defect or 
 
 The VergeOS interface will provide warnings or alerts to indicate when there is a problem with a physical drive. When a drive has a warning or error status, an indicator will "bubble up" to the System Dashboard page (Navigate to **System** > **Dashboard** from the top menu.)
 
-![Drive Count Box](/product-guide/screenshots/drivecountbox.png)
+![Drive Count Box](../screenshots/drivecountbox.png)
 
 - Click anywhere within the drive count box to access the full list of drives.
 - Double-click a drive with an error/warning to view its dashboard that displays more detail.
 
-![Drive listing warning](/product-guide/screenshots/drivelisting-warning.png)
+![Drive listing warning](../screenshots/drivelisting-warning.png)
 
-![Drive Dashboard](/product-guide/screenshots/drivedashboard.png)
+![Drive Dashboard](../screenshots/drivedashboard.png)
 
 ### Example Warning/Error Statuses
 
@@ -71,19 +71,19 @@ The replacement procedure depends on the current state of the drive:
 2. **Activate** the drive **LED**
     - If ***LED Status*** indicates **Off**, click **Turn on LED** on the left menu.
 
-    ![ledoff.png](/product-guide/screenshots/ledoff.png)
+    ![ledoff.png](../screenshots/ledoff.png)
 
     - If ***LED Status*** field indicates **Unsupported**, click **Locate LED** on the left menu.
 
-   ![ledunsupported.png](/product-guide/screenshots/ledunsupported.png)
+   ![ledunsupported.png](../screenshots/ledunsupported.png)
 
 3. The Diagnostics window will appear with settings pre-filled.  Click **Send ->** to activate the drive LED.
 
-    ![diag-ledon.png](/product-guide/screenshots/diag-ledon.png)
+    ![diag-ledon.png](../screenshots/diag-ledon.png)
 
 4. Once the LED is activated, the physical drive can be located by identifying the one with a solid light. After identifying the drive, **deactivate the LED**:
 
-![diag-ledoff.png](/product-guide/screenshots/diag-ledoff.png)
+![diag-ledoff.png](../screenshots/diag-ledoff.png)
 
 ## Scenario 1: Replace a Failed/Missing Drive
 

--- a/docs/product-guide/operations/maintenance-mode.md
+++ b/docs/product-guide/operations/maintenance-mode.md
@@ -48,23 +48,23 @@ When a node is put into Maintenance Mode, the system attempts to gracefully migr
     - **Node Logs**  
         Scroll to the bottom of the node dashboard to view node logs. A log entry will appear for each machine the system attempts to migrate. A log entry indicating the status is now *'Maintenance Mode'* indicates when the maintenance process completes successfully.
 
-        ![Node log complete](/product-guide/screenshots/nodelogcomplete.png)
+        ![Node log complete](../screenshots/nodelogcomplete.png)
 
         If any machines could not be migrated, an error entry will appear in the node logs; those machines will need to be powered off manually; see note above regarding Non-Migratable workloads.
 
     - **Running Machines**
         The *Running Machines* section indicates workloads currently on the node, both running and migrating. To successfully move into maintenance mode, all running machines need to be migrated or powered off; the Running Machines section will be empty when this has occurred.
 
-        ![Running machines - one migrating](/product-guide/screenshots/runningmachines-onemigrating.png)
+        ![Running machines - one migrating](../screenshots/runningmachines-onemigrating.png)
 
     - **Node Status**
         Node Status is displayed at the top of the node dashboard. While a node is in the process of migrating workloads, a status of ***"Migrating"*** is displayed.
 
-        ![Node status migrating](/product-guide/screenshots/nodestatusmigrating.png)
+        ![Node status migrating](../screenshots/nodestatusmigrating.png)
 
         A status of ***"Maintenance Mode"*** indicates that all workloads have been successfully migrated/powered off.
 
-        ![Node status maintenance mode](/product-guide/screenshots/nodestatusmaintenancemode.png)
+        ![Node status maintenance mode](../screenshots/nodestatusmaintenancemode.png)
 
 6. After verifying the ***Node Status*** displays **Maintenance Mode**, perform maintenance operations, using the **Reboot** **-And/Or-** **Power Off** options (on the left menu of the node dashboard) as needed.
 
@@ -79,10 +79,10 @@ When a node is put into Maintenance Mode, the system attempts to gracefully migr
 2. A Confirmation message will appear. Click **Yes** to continue taking the node out of Maintenance Mode.
 3. The ***Node Status*** displays "Leaving Maintenance" while in the process of coming out of Maintenance Mode.
 
-    ![Node status leaving maintenance](/product-guide/screenshots/nodestatusleavingmaint.png)
+    ![Node status leaving maintenance](../screenshots/nodestatusleavingmaint.png)
 
 4. The ***Node Status*** field will display "Running" when it has fully come out of Maintenance Mode and workloads have been migrated back to the node.
 
-    ![Node status running](/product-guide/screenshots/nodestatusrunning.png)
+    ![Node status running](../screenshots/nodestatusrunning.png)
 
 5. If necessary, **power on any non-migratable VMs or tenant nodes that were shutdown for maintenance**.

--- a/docs/product-guide/storage/preferred-tiers.md
+++ b/docs/product-guide/storage/preferred-tiers.md
@@ -28,4 +28,4 @@ The *Preferred Tier* setting will establish a "first choice" for the storage tie
 
 **The following illustration shows an example where tier 4 has been specified as the preferred tier:**
 
-![preferredtier.png](/product-guide/screenshots/preferredtier.png)
+![preferredtier.png](../screenshots/preferredtier.png)

--- a/docs/product-guide/storage/uploading-files-to-vsan.md
+++ b/docs/product-guide/storage/uploading-files-to-vsan.md
@@ -73,7 +73,7 @@ The *Files* section provides for uploading files to the VergeOS vSAN, allowing *
     - **Set Date** to select a specific date/time to cease the download link.
 7. Click **Submit** to save the link.
 
-![Media Images Link Copy](/product-guide/screenshots/mediaimages-link-copy.png)
+![Media Images Link Copy](../screenshots/mediaimages-link-copy.png)
 
 The Files list appears. Download options appear on the far right of the given file:
 

--- a/docs/product-guide/system/nvidia-vgpu-configuration.md
+++ b/docs/product-guide/system/nvidia-vgpu-configuration.md
@@ -159,10 +159,10 @@ After the resource group is selected or a new one is created, a **Success** mess
     ??? example "Example: MIG instance further divided into virtual instances"
         - **Physical device**: The RTX Pro 6000 Blackwell DC provides 96 GB of framebuffer memory
 
-        ![MIG-vGPU- Light Mode](/product-guide/screenshots/mig-vgpu-light.png#only-light)
+        ![MIG-vGPU- Light Mode](../screenshots/mig-vgpu-light.png#only-light)
 
 
-        ![MIG-vGPU - Dark Mode](/product-guide/screenshots/mig-vgpu-dark.png#only-dark)
+        ![MIG-vGPU - Dark Mode](../screenshots/mig-vgpu-dark.png#only-dark)
 
         - **MIG profile added**: Selecting the profile *NVIDIA RTX Pro 6000 Blackwell DC‑2‑12Q‑MIG (2g.48gb+gfx)* and specifying *MIG GPU Instances*:1 creates one MIG slice with 48 GB of dedicated framebuffer. This MIG slice supports **four vGPU instances**, each using **12 GB** (the “12Q” profile)
         - **Remaining capacity**: After allocating this 48 GB MIG slice, **48 GB of framebuffer** remains available for additional MIG profiles

--- a/docs/product-guide/system/sites-overview.md
+++ b/docs/product-guide/system/sites-overview.md
@@ -28,11 +28,11 @@ categories:
 
 The Sites Dashboard provides a central location for monitoring and administration of multiple VergeOS systems. This dashboard aggregates top-level statistics from all the systems to a single screen, with drill-down links to access and view more detailed information. A specific site page can be selected by clicking on its UI card or map coordinate pin (placement based on specified latitude/longitude values).
 
-![sitedash-main.png](/product-guide/screenshots/sitedash-main.png)
+![sitedash-main.png](../screenshots/sitedash-main.png)
 
 ### Example: Individual Site Page
 
-![sitepage.png](/product-guide/screenshots/sitepage.png)
+![sitepage.png](../screenshots/sitepage.png)
 
 - view more detailed information specific to the site
 - manage the site's networks, nodes, and VMs(if enabled)

--- a/docs/product-guide/system/subscriptions-accessing.md
+++ b/docs/product-guide/system/subscriptions-accessing.md
@@ -28,11 +28,11 @@ categories:
 **-OR-**
 * Click the **Subscriptions icon (top right)** and select **All My Subscriptions** (to view all) or select **Page Subscriptions** (to view only subscriptions associated to the current page.)  
 
-  ![subscriptions-icon-white.png](/product-guide/screenshots/subscriptions-icon-white.png)
+  ![subscriptions-icon-white.png](../screenshots/subscriptions-icon-white.png)
 
   The Subscriptions icon will be orange if you are subscribed to the current page (i.e. you own subscriptions that pertain to this part of the UI.)
 
-  ![subscriptions-icon-orange.png](/product-guide/screenshots/subscriptions-icon-orange.png)
+  ![subscriptions-icon-orange.png](../screenshots/subscriptions-icon-orange.png)
 
 ## Access All Subscriptions
 

--- a/docs/product-guide/system/subscriptions-overview.md
+++ b/docs/product-guide/system/subscriptions-overview.md
@@ -90,19 +90,19 @@ Dashboard or listing information is sent based on configured times/intervals. Th
 ### **Example 1 - vSAN Tier Dashboard**
 
 Receive a weekly summary for a particular vSAN Tier, including tier status, usage, read / write stats, etc.
-![subscription-vsantierdash.png](/product-guide/screenshots/subscription-vsantierdash.png)
+![subscription-vsantierdash.png](../screenshots/subscription-vsantierdash.png)
 
 ### **Example 2 - System Snapshots Recent**
 
 Receive a daily report with an inventory of all your Current System Snapshots.
-![subscription-cloudsnaps-recent.png](/product-guide/screenshots/subscription-cloudsnaps-recent.png)
+![subscription-cloudsnaps-recent.png](../screenshots/subscription-cloudsnaps-recent.png)
 
 ## **Examples - On-demand Subscriptions**
 
 ### **Example 3 - High Usage Alert for a Storage Tier**
 
 Receive an alert if Storage Tier 2 usage reaches the High Usage percentage (**The High Usage Percentage is set to 80% by default**); Send a reminder every 12 hours while the high usage is still in place.  **Throttle alerts to only send 2 per minute**.
-![subscription-highusagealert.png](/product-guide/screenshots/subscription-highusagealert.png)
+![subscription-highusagealert.png](../screenshots/subscription-highusagealert.png)
 
 !!! tip "A Separate Subscription could also be created for a Critical High Usage alert when a storage tier hits **90%**.  Typically, **you would have more frequent reminders** for a Critical High Usage alert."
 
@@ -111,7 +111,7 @@ Receive an alert if Storage Tier 2 usage reaches the High Usage percentage (**T
 Send an alert email to all members of the "SrvAdmin" group if any warning or error status changes occur on the Main Dashboard; send a Reminder email every **6 hours** while the Warning/Error condition is still in place; throttle the error messages to send only **1 per minute**.
 
 **Configuration:**
-![subscription-maindashwarnserrors.png](/product-guide/screenshots/subscription-maindashwarnserrors.png)
+![subscription-maindashwarnserrors.png](../screenshots/subscription-maindashwarnserrors.png)
 
  A vSAN tiers warning is an example of something that would appear in the Main Dashboard and trigger this subscription alert. Full Dashboard Data would be sent within the alert email message.
 

--- a/docs/product-guide/tenants/tenant-monitoring.md
+++ b/docs/product-guide/tenants/tenant-monitoring.md
@@ -83,14 +83,14 @@ The Subscription engine allows you to customize how and when you receive reports
 
 ### I. Example configuration - receive alerts for any status errors or warnings related to tenants:
 
-![tenantssubscription-alert](/product-guide/screenshots/tenantssubscription-alert.png)
+![tenantssubscription-alert](../screenshots/tenantssubscription-alert.png)
 
 ### II. Example configuration - 7:15 am daily report of the All-Tenants Dashboard (overview information):
 
-![tenantssubscription-report](/product-guide/screenshots/tenantssubscription-report.png)
+![tenantssubscription-report](../screenshots/tenantssubscription-report.png)
 
 ### III. Example configuration - weekly report (to the Administrators Group) showing summary information for a specific tenant:
 
-![singletenantsubscription-report](/product-guide/screenshots/singletenantsubscription-report.png)
+![singletenantsubscription-report](../screenshots/singletenantsubscription-report.png)
 
 There are many options available when creating subscriptions. For more information see: [**Subscriptions-Overview**](/product-guide/system/subscriptions-overview)

--- a/docs/product-guide/ui-overview.md
+++ b/docs/product-guide/ui-overview.md
@@ -143,8 +143,8 @@ The Networks Dashboard provides:
 - Network-specific logs and recent activity
 - Links to individual network dashboards for detailed management
 
-  ![Light mode Networks Dashboard](/product-guide/screenshots/networks-dashboard-light.png#only-light)
-  ![Dark mode Networks Dashboard](/product-guide/screenshots/networks-dashboard-dark.png#only-dark)
+  ![Light mode Networks Dashboard](screenshots/networks-dashboard-light.png#only-light)
+  ![Dark mode Networks Dashboard](screenshots/networks-dashboard-dark.png#only-dark)
 
 **Common Use Cases**:
 
@@ -185,8 +185,8 @@ A virtual machine's dashboard displays:
 - Network assignments and connectivity
 - Storage tier and volume information
 
-![Light mode VM Dashboard](/product-guide/screenshots/vm-dashboard-light.png#only-light)
-![Dark mode VM Dashboard](/product-guide/screenshots/vm-dashboard-dark.png#only-dark)
+![Light mode VM Dashboard](screenshots/vm-dashboard-light.png#only-light)
+![Dark mode VM Dashboard](screenshots/vm-dashboard-dark.png#only-dark)
 
 **Common Actions from VM Dashboard**:
 

--- a/docs/product-guide/virtual-machines/vm-guest-agent.md
+++ b/docs/product-guide/virtual-machines/vm-guest-agent.md
@@ -37,7 +37,7 @@ The guest agent is a program installed inside the guest OS allowing the host to 
 
 The guest agent must be enabled per VM; this can be done during VM creation or by editing an existing VM. The Guest Agent checkbox on the VM dashboard indicates if the agent is enabled.
 
-![agent-enabled-notconnected.png](/product-guide/screenshots/agent-enabled-notconnected.png)
+![agent-enabled-notconnected.png](../screenshots/agent-enabled-notconnected.png)
 
 ### Enable the Guest Agent on an existing VM
 
@@ -74,7 +74,7 @@ See the directions below for installing the guest agent software from the downlo
 
 1. Navigate to the **VM dashboard**.
 2. Click the CD-ROM selection button (top left)
-![fa-eject.png](/product-guide/screenshots/fa-eject.png)
+![fa-eject.png](../screenshots/fa-eject.png)
 3. Select **virtio-win.iso (or filename modified during download)**.
 4. Click **Submit** to apply the CD change.
 5. Click **Remote Console** on the left menu to console into the guest OS.
@@ -114,4 +114,4 @@ On Linux VMs, the **qemu-guest-agent package** must be installed. Installation i
 
 When a guest agent is successfully connected, the version number will display next to the checked Guest Agent checkbox on the VM dashboard.
 
-![agent-connected-version.png](/product-guide/screenshots/agent-connected-version.png)
+![agent-connected-version.png](../screenshots/agent-connected-version.png)

--- a/docs/product-guide/virtual-machines/vm-remote-console.md
+++ b/docs/product-guide/virtual-machines/vm-remote-console.md
@@ -28,30 +28,30 @@ categories:
 
 The remote console provides direct interaction (mouse/keyboard) with Virtual Machines.
 
-![vdi-console.png](/product-guide/screenshots/vdi-console.png)
+![vdi-console.png](../screenshots/vdi-console.png)
 
 ## Console Toolbar
 All toolbar options, except the *Exit* button, work as a toggle, switching between on/open or off/closed. For example: clicking the chat button opens the chat window, and clicking the button again closes the chat window. A button is orange when on/open; white when off/closed.
 
-#### ![exiticon.png](/product-guide/screenshots/exiticon.png) Exit
+#### ![exiticon.png](../screenshots/exiticon.png) Exit
 Exits the console and returns to the previous screen.
 
-####  ![expandconsole-icon.png](/product-guide/screenshots/expandconsole-icon.png) Expand console
+####  ![expandconsole-icon.png](../screenshots/expandconsole-icon.png) Expand console
 Activates/deactivates the console's full-screen option (expand to entire browser tab)
 
-#### ![virtkeyboard-icon.png](/product-guide/screenshots/virtkeyboard-icon.png) Virtual Keyboard
+#### ![virtkeyboard-icon.png](../screenshots/virtkeyboard-icon.png) Virtual Keyboard
 Provides a virtual keyboard on devices that do not have a physical keyboard (cellphones, tablets, etc.)
 
-#### ![dragview-icon.png](/product-guide/screenshots/dragview-icon.png) Drag view port
+#### ![dragview-icon.png](../screenshots/dragview-icon.png) Drag view port
 Alows moving the viewable portion of the console when the guest system screen exceeds the viewable area.
 
-#### ![browserfullscreen-icon.png](/product-guide/screenshots/browserfullscreen-icon.png) Toggle Browser Full Screen
+#### ![browserfullscreen-icon.png](../screenshots/browserfullscreen-icon.png) Toggle Browser Full Screen
 Activates/deactivates the browser's full-screen option.
 
-#### ![eject-icon.png](/product-guide/screenshots/eject-icon.png) Change/Eject CD-ROM
+#### ![eject-icon.png](../screenshots/eject-icon.png) Change/Eject CD-ROM
 Toggles the view of the CD-ROM selection form, where an \*.iso file is selected.
 
-#### ![clipboard-icon.png](/product-guide/screenshots/clipboard-icon.png) Clipboard
+#### ![clipboard-icon.png](../screenshots/clipboard-icon.png) Clipboard
 Opens the clipboard window where text can be placed to insert into the Virtual Machine.
    - The **Close** button will close the Clipboard window (can also be closed by clicking the Clipboard button again).
    - The **Clear** button clears current contents from the Clipboard.
@@ -60,13 +60,13 @@ Opens the clipboard window where text can be placed to insert into the Virtual M
 !!! note
     Wait until all contents have successfully pasted into the console before performing any other clipboard operations, typing, or moving cursor within the VM.
     
-#### ![power-icon.png](/product-guide/screenshots/power-icon.png) Power
+#### ![power-icon.png](../screenshots/power-icon.png) Power
 Opens/closes the power buttons window:
    - **\[Reset\]** - restarts the VM operating system; does not power down the virtual hardware.
    - **\[ACPI\]** - Power down (graceful)
    - **\[Kill\]** - Power down (ungraceful) - use as a last resort when guest OS is locked and graceful shutdown is not an option.
     
-#### ![extrakeys-icon.png](/product-guide/screenshots/extrakeys-icon.png) Extra Keys
+#### ![extrakeys-icon.png](../screenshots/extrakeys-icon.png) Extra Keys
 opens/closes the extra keys window, which allows simulating keyboard operations to the machine, such as:
  - **\[Ctrl-Alt-Del\]**
  - **\[Ctrl\]\***
@@ -79,5 +79,5 @@ opens/closes the extra keys window, which allows simulating keyboard operations 
 !!! tip
     A full virtual keyboard option is also visible when using a mobile device, such as a cell phone or tablet
 
-#### ![chat-icon.png](/product-guide/screenshots/chat-icon.png) Chat
+#### ![chat-icon.png](../screenshots/chat-icon.png) Chat
 opens/closes the chat window where all users that are consoled into the virtual machine can share messages with each other.

--- a/docs/product-guide/vpn/ipsec.md
+++ b/docs/product-guide/vpn/ipsec.md
@@ -192,7 +192,7 @@ Additional network configuration (e.g. firewall rules, routing) will be required
 1. From the **VPN Network Dashboard**, click **Power On** from the left menu.
 2. Click the Plug icon under **IPsec Connections**.  
 
-![IPsec Connect button](/product-guide/screenshots/ipsec-connect.png) 
+![IPsec Connect button](../screenshots/ipsec-connect.png) 
 
 3. Watch for the IPsec status to show connected.
 

--- a/docs/product-guide/vpn/wireguard-examples.md
+++ b/docs/product-guide/vpn/wireguard-examples.md
@@ -47,8 +47,8 @@ For this example, "SystemA" and "SystemB" will be used to denote the 2 VergeOS s
         - add an entry for the address of the **WireGuard interface on SystemA**.
         - add an entry for the **connected network on SystemA** (e.g. the network to which WireGuard is connected.
 
-![guard-b-peer.png](/product-guide/screenshots/guard-b-peer.png)
-![guard-b-peer2.png](/product-guide/screenshots/guard-b-peer2.png)
+![guard-b-peer.png](../screenshots/guard-b-peer.png)
+![guard-b-peer2.png](../screenshots/guard-b-peer2.png)
 5. **While still on SystemB**, copy the generated public key, using the copy icon.
 
 **On SystemA:**  
@@ -57,8 +57,8 @@ For this example, "SystemA" and "SystemB" will be used to denote the 2 VergeOS s
     - In the ***Allowed IPs*** section:
         - add an entry for the address of the WireGuard interface on **SystemB**.
         - add an entry for the **connected network on SystemB** (e.g. the network to which WireGuard is connected.)
-   ![guard-a-peer.png](/product-guide/screenshots/guard-a-peer.png)
-   ![guard-a-peer2.png](/product-guide/screenshots/guard-a-peer2.png)        
+   ![guard-a-peer.png](../screenshots/guard-a-peer.png)
+   ![guard-a-peer2.png](../screenshots/guard-a-peer2.png)        
 
 **On SystemA AND SystemB:**  
 7. **Apply Rules** (on the networks where Wireguard interfaces were created) to put system-generated network rules into effect.
@@ -67,7 +67,7 @@ For this example, "SystemA" and "SystemB" will be used to denote the 2 VergeOS s
 
 A simple ping test can be done using the Diagnostics Tool on each system as an initial test of the connection.
 
-**On SystemA:** navigate to the Network Dashboard (the network to which WireGuard is attached) ![guard-a-pingtest.png](/product-guide/screenshots/guard-a-pingtest.png)
+**On SystemA:** navigate to the Network Dashboard (the network to which WireGuard is attached) ![guard-a-pingtest.png](../screenshots/guard-a-pingtest.png)
 
 - **Select ping** from the Query list dropdown.
 - **Ping the interface address on SystemB**(from our example: 192.68.1.2)
@@ -89,22 +89,22 @@ This example covers setup for a single, remote access peer (a Windows client), a
 7. Enter the ***Endpoint*** for the Peer (the external-facing IP address, hostname, or URL this system will use to communicate with the peer.)
 8. In the ***Configure Firewall*** dropdown, select **Remote user**
 9. Click **Submit** to save the new peer entry.
-    ![client-peer-form.png](/product-guide/screenshots/client-peer-form.png)
+    ![client-peer-form.png](../screenshots/client-peer-form.png)
 
 ### Download the Configuration File
 
 Click the Download Config button on the peer record and select a location for the file; download to a location that will be accessible to the client computer or from which can otherwise be transferred to the client.
 
-![download-link.png](/product-guide/screenshots/download-link.png)
-![configuration-file.png](/product-guide/screenshots/configuration-file.png)
+![download-link.png](../screenshots/download-link.png)
+![configuration-file.png](../screenshots/configuration-file.png)
 
 ### Install WireGuard Software on Client
 
 WireGuard Client software can be downloaded from: https://wireguard.com/install.
 (In this example, we download and install WireGuard for Windows-64bit to use on a Windows 10 Pro machine.)
-    ![add-tunnel.png](/product-guide/screenshots/add-tunnel.png)
+    ![add-tunnel.png](../screenshots/add-tunnel.png)
 
 1. Click **Add Tunnel**.
 2. Navigate to and **select the generated configuration file**.
 3. The configuration file is used to automatically create an interface and peer on the client machine. Click the **Activate** button to open the tunnel, if it was not automatically activated.
-   ![tunnel-active.png](/product-guide/screenshots/tunnel-active.png)
+   ![tunnel-active.png](../screenshots/tunnel-active.png)

--- a/docs/product-guide/vsan/uploading-files-to-vsan.md
+++ b/docs/product-guide/vsan/uploading-files-to-vsan.md
@@ -75,7 +75,7 @@ The *Files* section provides for uploading files to the VergeOS vSAN, allowing *
     - **Set Date** to select a specific date/time to cease the download link.
 7. Click **Submit** to save the link.
 
-![Media Images Link Copy](/product-guide/screenshots/mediaimages-link-copy.png)
+![Media Images Link Copy](../screenshots/mediaimages-link-copy.png)
 
 The Files list appears. Download options appear on the far right of the given file:
 


### PR DESCRIPTION
## Summary

Diagram and screenshot images across the site now render when served from the GitHub Pages subpath. Previously, 178 image references across 48 files used site-root-absolute paths (`/assets/...`, `/product-guide/screenshots/...`) that the browser resolved to `verge-io.github.io/assets/...` instead of `verge-io.github.io/docs/assets/...`, returning 404s.

## How it was encountered

The network design diagrams (`layer2bonded-dc.png`, `layer3bonded-dc.png`) were reported missing on https://verge-io.github.io/docs/implementation-guide/network-design/. Investigation showed the images have been in `docs/assets/` all along; the markdown referenced them with site-root-absolute paths, which only work when the site sits at a domain root. This site is deployed under the `/docs/` subpath, so every absolute image path on the site 404s. The new GitBook site at docs.verge.io is unaffected because GitBook rewrites its own image URLs.

## Resolution

Converted every absolute image path to a relative path (already the convention documented in CLAUDE.md), which resolves correctly at any base path, including if this build is ever served from a domain root. One filename containing parentheses (`vergeio-traffic-flow_(1).png`) is percent-encoded so markdown parses the link correctly.

## Verification

- The conversion checked that every target file exists before rewriting, so no dangling references were introduced.
- `mkdocs build` completes with no image-related warnings.
- All 1,149 `img src` attributes in the built HTML were resolved against the filesystem: 0 broken.

Note: 3 absolute page links (not images) in `docs/knowledge-base/posts/snapshot-sync-errors.md` have the same subpath problem and were left for a follow-up.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)
